### PR TITLE
Dev clarification

### DIFF
--- a/source/app-development/enabling-development-mode.rst
+++ b/source/app-development/enabling-development-mode.rst
@@ -7,9 +7,21 @@ Enabling App Development
 1. Enable App Development Mode in Dashboard
 -------------------------------------------
 
-Enable App Development Mode in the Dashboard in two ways:
+Enable App Development Mode in the Dashboard in three ways:
 
-A. Enable for every user using environment variable
+A. Enable your own account by creating the sandbox directory 
+............................................................
+
+Each user can by default enable app development by creating the directory that holds the sandbox apps. In a Shell session, create the dev directory in your home directory:
+
+.. code-block:: sh
+
+   mkdir -p ~/ondemand/dev
+
+Then reload OnDemand dashboard to see the Develop dropdown appear. Note: this will work only if the administrator has not configured the dashboard to enable or disable app development in the dashboard.
+
+
+B. Enable for every user using environment variable
 ...................................................
 
 In the root of the dashboard app, add these contents to a file ``.env.local``:
@@ -24,7 +36,7 @@ set to true, and the Develop dropdown will
 appear.
 
 
-B. Enable for specific users using custom initializer
+C. Enable for specific users using custom initializer
 .....................................................
 
 Create a custom initializer file in the Dashboard app: ``config/initializers/ood.rb``

--- a/source/applications.rst
+++ b/source/applications.rst
@@ -6,6 +6,28 @@ Applications
 These are the apps deployed by the system administrator on the local disk that
 are accessible by all users.
 
+
+
+.. list-table:: OnDemand System Access Apps
+   :header-rows: 1
+
+   * - Name
+     - GitHub URL
+   * - Dashboard
+     - https://github.com/OSC/ood-dashboard
+   * - Shell
+     - https://github.com/OSC/ood-shell
+   * - Files
+     - https://github.com/OSC/ood-fileexplorer
+   * - Editor
+     - https://github.com/OSC/ood-fileeditor
+   * - Active Jobs
+     - https://github.com/OSC/ood-activejobs
+   * - Job Composer
+     - https://github.com/OSC/ood-myjobs
+   * - Interactive Apps: Desktop
+     - https://github.com/OSC/bc_desktop
+
 .. toctree::
    :maxdepth: 2
    :caption: Components

--- a/source/infrastructure.rst
+++ b/source/infrastructure.rst
@@ -6,6 +6,22 @@ Infrastructure
 These are the components that make up the Open OnDemand infrastructure allowing
 for users to connect to web applications running as their local system account.
 
+
+.. list-table:: OnDemand Infrastructure Components
+   :header-rows: 1
+
+   * - Name
+     - GitHub URL
+   * - ood-portal-generator
+     - https://github.com/OSC/ood-portal-generator
+   * - mod_ood_proxy
+     - https://github.com/OSC/mod_ood_proxy
+   * - ood_auth_map
+     - https://github.com/OSC/ood_auth_map
+   * - nginx_stage
+     - https://github.com/OSC/nginx_stage
+
+
 .. toctree::
    :maxdepth: 2
    :caption: Components

--- a/source/infrastructure.rst
+++ b/source/infrastructure.rst
@@ -17,7 +17,7 @@ for users to connect to web applications running as their local system account.
    * - mod_ood_proxy
      - https://github.com/OSC/mod_ood_proxy
    * - ood_auth_map
-     - https://github.com/OSC/ood_auth_map
+     - https://github.com/OSC/ood_auth_map
    * - nginx_stage
      - https://github.com/OSC/nginx_stage
 


### PR DESCRIPTION
Clarify enabling development mode and add tables to apps and infrastructure fixes https://github.com/OSC/ood-documentation/issues/71

Preview of changes:

1. https://osc.github.io/ood-documentation-test/dev_clarification/app-development/enabling-development-mode.html
2. https://osc.github.io/ood-documentation-test/dev_clarification/applications.html
3. https://osc.github.io/ood-documentation-test/dev_clarification/infrastructure.html