### PR TITLE
Document that EPEL is needed for upgrade and add EL6 vs EL7 sections

### DIFF
--- a/source/release-notes/v1.4-release-notes.rst
+++ b/source/release-notes/v1.4-release-notes.rst
@@ -23,11 +23,24 @@ Highlights in 1.4:
 Upgrading from v1.3
 -------------------
 
-To upgrade run:
+#. Enable EPEL and update OnDemand release RPM
+
+   CentOS/RHEL 6
+     .. code-block:: sh
+
+        sudo install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+        sudo install -y https://yum.osc.edu/ondemand/1.4/ondemand-release-web-1.4-1.el6.noarch.rpm
+
+   CentOS/RHEL 7
+     .. code-block:: sh
+
+        sudo install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        sudo install -y https://yum.osc.edu/ondemand/1.4/ondemand-release-web-1.4-1.el7.noarch.rpm
+
+#. Update OnDemand
 
 .. code-block:: bash
 
-    sudo yum install -y https://yum.osc.edu/ondemand/1.4/ondemand-release-web-1.4-1.el7.noarch.rpm
     sudo yum clean all
     sudo yum update ondemand
 


### PR DESCRIPTION
Since we didn't actually depend on EPEL before 1.4 it would be good to document that the upgrade should involve adding EPEL.

Also split the repo steps into EL6 and EL7 sections to make it clear the repo used is OS version specific.