### PR TITLE
Update RStudio docs to use the newer, simpler BINDPATH

### DIFF
--- a/source/app-development/tutorials-interactive-apps/add-rstudio/customize-attributes.rst
+++ b/source/app-development/tutorials-interactive-apps/add-rstudio/customize-attributes.rst
@@ -38,7 +38,7 @@ The main responsibility of the ``form.yml`` file (:ref:`app-development-interact
     help([[ rstudio - loads rstudio with singularity environment for ondemand apps ]])
     whatis("loads rstudio with singularity environment for ondemand")
     setenv("RSTUDIO_SERVER_IMAGE","/usr/local/project/ondemand/singularity/rstudio/rstudio_launcher_centos7.simg")
-    setenv("SINGULARITY_BINDPATH","/usr/lib,/usr/lib64,/bin,/usr/share,/usr/include")
+    setenv("SINGULARITY_BINDPATH","/etc,/media,/mnt,/opt,/srv,/usr,/var")
     append_path("PATH", "/usr/lib/rstudio-server/bin)
 
   Then replace the exports in the function ``setup_env`` with the appropriate ``module use $module_path`` and ``module load rstudio_container/v0.0.1``.
@@ -49,7 +49,16 @@ The main responsibility of the ``form.yml`` file (:ref:`app-development-interact
       # Additional environment which could be moved into a module
       # Change these to suit
       # export RSTUDIO_SERVER_IMAGE="/apps/rserver-launcher-centos7.simg"
-      # export SINGULARITY_BINDPATH="/usr/lib,/usr/lib64,/bin,/usr/share,/usr/include"
+      # The most robust SINGULARITY_BINDPATH appears to be: /etc,/media,/mnt,/opt,/srv,/usr,/var.
+      # That, plus Singularity's standard auto-mounts, covers most of the Filesystem Hierarchy Standard.
+      #
+      # Notable exceptions include:
+      #
+      #     - /tmp which we are explicitly overriding
+      #     - those directories which in Centos 7 are commonly symlinks to/usr
+      #     - root's home directory
+      #
+      # export SINGULARITY_BINDPATH="/etc,/media,/mnt,/opt,/srv,/usr,/var"
       # export PATH="$PATH:/usr/lib/rstudio-server/bin"
       # export SINGULARITYENV_PATH="$PATH"
       module use "$path/to/lmodfiles"

--- a/source/app-development/tutorials-interactive-apps/add-rstudio/setup-singularity.rst
+++ b/source/app-development/tutorials-interactive-apps/add-rstudio/setup-singularity.rst
@@ -19,7 +19,7 @@ Alternatively, Build The Singularity Image
 
 Running a build is trivial but does require sudoer access to the build host.
 
-Where ``Singularity`` is the file that defines the image. The image is basic, installing only the command ``which`` over the base CentOS 7 packages. This simplicity is because most of the actual executables and libraries must be bound and mounted into the container/guest at runtime from the host. By bind-mounting executables and libaries from the host system we are able to swap RStudio versions at launch time without having to update the Singuarlity image.
+Where ``Singularity`` is the file that defines the image. The image is just the base CentOS 7 packages plus a run script. This simplicity is because the actual executables and libraries must be bound and mounted into the container/guest at runtime from the host. By bind-mounting executables and libaries from the host system we are able to swap RStudio versions at launch time without having to update the Singuarlity image.
 
 Likewise the runscript defined in the image uses the host ``$PATH`` which is propagated into the guest's environment as ``$USER_PATH``.
 
@@ -51,6 +51,3 @@ An example Singularity file for running RStudio:
         fi
 
         exec rserver "${@}"
-
-      %post
-      yum install -y which


### PR DESCRIPTION
Update RStudio example to use a more robust BINDPATH and remove the installation of `which` since it will be mounted in anyway.