### PR TITLE
Update the netcat link to point to the nmap version instead of the GN…

### DIFF
--- a/source/app-development/interactive/setup/software-requirements.rst
+++ b/source/app-development/interactive/setup/software-requirements.rst
@@ -22,4 +22,4 @@ For VNC server support:
 
 .. _turbovnc: https://turbovnc.org/
 .. _websockify: https://github.com/novnc/websockify
-.. _nmap-ncat: http://netcat.sourceforge.net/
+.. _nmap-ncat: https://nmap.org/ncat/


### PR DESCRIPTION
…U version.

@fenz points out that the GNU version which was previously linked will not accept /dev/null as input which will cause the function port_used to hang.

Fixes #165.