### PR TITLE
More in depth configuration of SElinux and iptables for 1.5

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -22,17 +22,17 @@
         },
         "babel": {
             "hashes": [
-                "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
-                "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
+                "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
+                "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"
             ],
-            "version": "==2.6.0"
+            "version": "==2.7.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -40,6 +40,14 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.1"
         },
         "docutils": {
             "hashes": [
@@ -51,10 +59,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
-                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
-            "version": "==2.7"
+            "version": "==2.8"
         },
         "imagesize": {
             "hashes": [
@@ -65,56 +73,85 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "packaging": {
             "hashes": [
-                "sha256:0886227f54515e592aaa2e5a553332c73962917f2831f1b0f9b9f4380a4b9807",
-                "sha256:f95a1e147590f204328170981833854229bb2912ac3d5f89e2a8ccd2834800c9"
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
             ],
-            "version": "==18.0"
+            "version": "==19.0"
         },
         "pygments": {
             "hashes": [
-                "sha256:6301ecb0997a52d2d31385e62d0a4a4cf18d2f2da7054a5ddad5c366cd39cee7",
-                "sha256:82666aac15622bd7bb685a4ee7f6625dd716da3ef7473620c192c0168aae64fc"
+                "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
+                "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
             ],
-            "version": "==2.3.0"
+            "version": "==2.4.2"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b"
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
             ],
-            "version": "==2.3.0"
+            "version": "==2.4.0"
         },
         "pytz": {
             "hashes": [
-                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
             ],
-            "version": "==2018.7"
+            "version": "==2019.1"
         },
         "requests": {
             "hashes": [
-                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
-                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
-            "version": "==2.20.1"
+            "version": "==2.22.0"
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -125,17 +162,38 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:120732cbddb1b2364471c3d9f8bfd4b0c5b550862f99a65736c77f970b142aea",
-                "sha256:b348790776490894e0424101af9c8413f2a86831524bd55c5f379d3e3e12ca64"
+                "sha256:423280646fb37944dd3c85c58fb92a20d745793a9f6c511f59da82fa97cd404b",
+                "sha256:de930f42600a4fef993587633984cc5027dedba2464bcf00ddace26b40f8d9ce"
             ],
-            "version": "==1.8.2"
+            "version": "==2.0.1"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:02f02a676d6baabb758a20c7a479d58648e0f64f13e07d1b388e9bb2afe86a09",
-                "sha256:d0f6bc70f98961145c5b0e26a992829363a197321ba571b31b24ea91879e0c96"
+                "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4",
+                "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"
             ],
-            "version": "==0.4.2"
+            "version": "==0.4.3"
+        },
+        "sphinxcontrib-applehelp": {
+            "hashes": [
+                "sha256:edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897",
+                "sha256:fb8dee85af95e5c30c91f10e7eb3c8967308518e0f7488a2828ef7bc191d0d5d"
+            ],
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-devhelp": {
+            "hashes": [
+                "sha256:6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34",
+                "sha256:9512ecb00a2b0821a146736b39f7aeb90759834b07e81e8cc23a9c70bacb9981"
+            ],
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-htmlhelp": {
+            "hashes": [
+                "sha256:4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422",
+                "sha256:d4fd39a65a625c9df86d7fa8a2d9f3cd8299a3a4b15db63b50aac9e161d8eff7"
+            ],
+            "version": "==1.0.2"
         },
         "sphinxcontrib-httpdomain": {
             "hashes": [
@@ -144,34 +202,39 @@
             ],
             "version": "==1.7.0"
         },
+        "sphinxcontrib-jsmath": {
+            "hashes": [
+                "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
+                "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
+            ],
+            "version": "==1.0.1"
+        },
         "sphinxcontrib-plantuml": {
             "hashes": [
-                "sha256:95a453e1d912bfdd6a950f8df02f46608154676842d66f8a0d1db0b85a5ddfe5"
+                "sha256:c3207524e8e03f223482681e120575f065e6b09d54c7e43738162ba7d29cfb39"
             ],
-            "version": "==0.12"
+            "version": "==0.16"
         },
-        "sphinxcontrib-websupport": {
+        "sphinxcontrib-qthelp": {
             "hashes": [
-                "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
-                "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
+                "sha256:513049b93031beb1f57d4daea74068a4feb77aa5630f856fcff2e50de14e9a20",
+                "sha256:79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f"
             ],
-            "version": "==1.1.0"
+            "version": "==1.0.2"
         },
-        "typing": {
+        "sphinxcontrib-serializinghtml": {
             "hashes": [
-                "sha256:4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d",
-                "sha256:57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4",
-                "sha256:a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a"
+                "sha256:c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227",
+                "sha256:db6615af393650bf1151a6cd39120c29abaf93cc60db8c48eb2dddbfdc3a9768"
             ],
-            "markers": "python_version < '3.5'",
-            "version": "==3.6.6"
+            "version": "==1.1.3"
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
-            "version": "==1.24.1"
+            "version": "==1.25.3"
         }
     },
     "develop": {}

--- a/source/installation/modify-system-security.rst
+++ b/source/installation/modify-system-security.rst
@@ -3,25 +3,16 @@
 Modify System Security
 ======================
 
-#. Disable `SELinux`_ on the Open OnDemand host you intend on running the web
-   server on.
-
-   .. note::
-
-      If SELinux is not disabled on the web server host machine this can lead
-      to permission errors when running the web applications. SELinux may also
-      need to be disabled on the web server if you want to take advantage of
-      certain software in your web applications such as being able to access a
-      Lustre file system.
-
+#. Check `SELinux`_ status, by default SELinux is enabled on CentOS and most other RHEL-based systems.
+   
    RHEL/CentOS 6/7
       .. code-block:: sh
 
-         sestatus
+         $ sestatus
 
       .. code-block:: sh
 
-         #Output
+         #Output displays the starting status of SELinux
          **SELinux status**:             **enabled**
          SELinuxfs mount:                /sys/fs/selinux
          SELinux root directory:         /etc/selinux
@@ -32,27 +23,52 @@ Modify System Security
          Policy deny_unknown status:     allowed
          Max kernel policy version:      31
 
+#. Disable `SELinux`_ on the Open OnDemand host you intend on running the web
+   server on. 
 
-   RHEL/CentOS 6/7
-      .. code-block:: sh
+   .. note::
 
-         $ sudo chmod -R 757 /etc/selinux/config  
+      If SELinux is not disabled on the web server host machine this can lead
+      to permission errors when running the web applications. SELinux may also
+      need to be disabled on the web server if you want to take advantage of
+      certain software in your web applications such as being able to access a
+      Lustre file system.
 
-   Using your favorite text editor open the /etc/selinux/config file and set the SELINUX mode to disabled 
 
-      .. code-block:: sh
+   **Option 1: Disable SELinux Temporarily**
+      
+      #. To temporarily disable SELinux, use the following command:
 
-         This file controls the state of SELinux on the system.
-         # SELINUX= can take one of these three values:
-         #       enforcing - SELinux security policy is enforced.
-         #       permissive - SELinux prints warnings instead of enforcing.
-         #       disabled - No SELinux policy is loaded.
-         SELINUX=disabled
-         # SELINUXTYPE= can take one of these two values:
-         #       targeted - Targeted processes are protected,
-         #       mls - Multi Level Security protection.
-         SELINUXTYPE=targeted
+         RHEL/CentOS 6/7
+            .. code-block:: sh
+               
+               $ setenforce 0  
+      
 
+   **Option 2: Disable SELinux Permanently**
+      
+      #. Using your favorite text editor open the /etc/selinux/config file and change the **SELINUX=enforcing** directive to **SELINUX=disabled**.
+
+         RHEL/CentOS 6/7
+            .. code-block:: sh
+
+               This file controls the state of SELinux on the system.
+               # SELINUX= can take one of these three values:
+               #       enforcing - SELinux security policy is enforced.
+               #       permissive - SELinux prints warnings instead of enforcing.
+               #       disabled - No SELinux policy is loaded.
+               SELINUX=disabled
+               # SELINUXTYPE= can take one of these two values:
+               #       targeted - Targeted processes are protected,
+               #       mls - Multi Level Security protection.
+               SELINUXTYPE=targeted
+
+      #. Reboot the OS to save the changes 
+
+         RHEL/CentOS 6/7
+            .. code-block:: sh
+
+               $ shutdown -r now
 
 #. Open ports 80 (http) and 443 (https) in the firewall, typically done with
    `iptables`_.
@@ -73,7 +89,7 @@ Modify System Security
 
    RHEL/CentOS 6
       .. code-block:: sh
-      
+
          $ sudo iptables -I INPUT -p tcp -m tcp --dport 80 -j ACCEPT
          $ sudo iptables -I INPUT -p tcp -m tcp --dport 443 -j ACCEPT
          $ sudo service iptables save    

--- a/source/installation/modify-system-security.rst
+++ b/source/installation/modify-system-security.rst
@@ -14,6 +14,46 @@ Modify System Security
       certain software in your web applications such as being able to access a
       Lustre file system.
 
+   RHEL/CentOS 6/7
+      .. code-block:: sh
+
+         sestatus
+
+      .. code-block:: sh
+
+         #Output
+         **SELinux status**:             **enabled**
+         SELinuxfs mount:                /sys/fs/selinux
+         SELinux root directory:         /etc/selinux
+         Loaded policy name:             targeted
+         Current mode:                   enforcing
+         Mode from config file:          enforcing
+         Policy MLS status:              enabled
+         Policy deny_unknown status:     allowed
+         Max kernel policy version:      31
+
+
+   RHEL/CentOS 6/7
+      .. code-block:: sh
+
+         $ sudo chmod -R 757 /etc/selinux/config  
+
+   Using your favorite text editor open the /etc/selinux/config file and set the SELINUX mode to disabled 
+
+      .. code-block:: sh
+
+         This file controls the state of SELinux on the system.
+         # SELINUX= can take one of these three values:
+         #       enforcing - SELinux security policy is enforced.
+         #       permissive - SELinux prints warnings instead of enforcing.
+         #       disabled - No SELinux policy is loaded.
+         SELINUX=disabled
+         # SELINUXTYPE= can take one of these two values:
+         #       targeted - Targeted processes are protected,
+         #       mls - Multi Level Security protection.
+         SELINUXTYPE=targeted
+
+
 #. Open ports 80 (http) and 443 (https) in the firewall, typically done with
    `iptables`_.
 
@@ -22,6 +62,21 @@ Modify System Security
       If using **RHEL 7** you will need to either use the newer `firewalld`_
       daemon and modify the firewall settings or disable it and install
       `iptables`_.
+
+   RHEL/CentOS 7
+      .. code-block:: sh
+
+         $ systemctl restart firewalld
+         $ sudo firewall-cmd --zone=public --add-port=80/tcp --permanent
+         $ sudo firewall-cmd --zone=public --add-port=443/tcp --permanent
+         $ sudo firewall-cmd --reload
+
+   RHEL/CentOS 6
+      .. code-block:: sh
+      
+         $ sudo iptables -I INPUT -p tcp -m tcp --dport 80 -j ACCEPT
+         $ sudo iptables -I INPUT -p tcp -m tcp --dport 443 -j ACCEPT
+         $ sudo service iptables save    
 
 .. _selinux: https://wiki.centos.org/HowTos/SELinux
 .. _iptables: https://wiki.centos.org/HowTos/Network/IPTables

--- a/source/installation/modify-system-security.rst
+++ b/source/installation/modify-system-security.rst
@@ -5,23 +5,23 @@ Modify System Security
 
 #. Check `SELinux`_ status, by default SELinux is enabled on CentOS and most other RHEL-based systems.
    
-   RHEL/CentOS 6/7
-      .. code-block:: sh
+      RHEL/CentOS 6/7
+         .. code-block:: sh
 
-         $ sestatus
+            $ sestatus
 
-      .. code-block:: sh
+         .. code-block:: sh
 
-         #Output displays the starting status of SELinux
-         **SELinux status**:             **enabled**
-         SELinuxfs mount:                /sys/fs/selinux
-         SELinux root directory:         /etc/selinux
-         Loaded policy name:             targeted
-         Current mode:                   enforcing
-         Mode from config file:          enforcing
-         Policy MLS status:              enabled
-         Policy deny_unknown status:     allowed
-         Max kernel policy version:      31
+            #Output displays the starting status of SELinux
+            **SELinux status**:             **enabled**
+            SELinuxfs mount:                /sys/fs/selinux
+            SELinux root directory:         /etc/selinux
+            Loaded policy name:             targeted
+            Current mode:                   enforcing
+            Mode from config file:          enforcing
+            Policy MLS status:              enabled
+            Policy deny_unknown status:     allowed
+            Max kernel policy version:      31
 
 #. Disable `SELinux`_ on the Open OnDemand host you intend on running the web
    server on. 
@@ -34,41 +34,29 @@ Modify System Security
       certain software in your web applications such as being able to access a
       Lustre file system.
 
-
-   **Option 1: Disable SELinux Temporarily**
       
-      #. To temporarily disable SELinux, use the following command:
+   #. Using your favorite text editor open the /etc/selinux/config file and change the **SELINUX=enforcing** directive to **SELINUX=disabled**.
 
-         RHEL/CentOS 6/7
-            .. code-block:: sh
-               
-               $ setenforce 0  
-      
+      RHEL/CentOS 6/7
+         .. code-block:: sh
 
-   **Option 2: Disable SELinux Permanently**
-      
-      #. Using your favorite text editor open the /etc/selinux/config file and change the **SELINUX=enforcing** directive to **SELINUX=disabled**.
+            This file controls the state of SELinux on the system.
+            # SELINUX= can take one of these three values:
+            #       enforcing - SELinux security policy is enforced.
+            #       permissive - SELinux prints warnings instead of enforcing.
+            #       disabled - No SELinux policy is loaded.
+            SELINUX=disabled
+            # SELINUXTYPE= can take one of these two values:
+            #       targeted - Targeted processes are protected,
+            #       mls - Multi Level Security protection.
+            SELINUXTYPE=targeted
 
-         RHEL/CentOS 6/7
-            .. code-block:: sh
+   #. Disable SELinux
 
-               This file controls the state of SELinux on the system.
-               # SELINUX= can take one of these three values:
-               #       enforcing - SELinux security policy is enforced.
-               #       permissive - SELinux prints warnings instead of enforcing.
-               #       disabled - No SELinux policy is loaded.
-               SELINUX=disabled
-               # SELINUXTYPE= can take one of these two values:
-               #       targeted - Targeted processes are protected,
-               #       mls - Multi Level Security protection.
-               SELINUXTYPE=targeted
+      RHEL/CentOS 6/7
+         .. code-block:: sh
 
-      #. Reboot the OS to save the changes 
-
-         RHEL/CentOS 6/7
-            .. code-block:: sh
-
-               $ shutdown -r now
+             $ setenforce 0 
 
 #. Open ports 80 (http) and 443 (https) in the firewall, typically done with
    `iptables`_.


### PR DESCRIPTION
Modified the 1.5 build instructions, to display more in depth detail surrounding :

Disabling SELinux
-Opening iptables
Instructions pertain to centOS/RHEL 6/7