### PR TITLE
Simplify requirements

### DIFF
--- a/source/requirements.rst
+++ b/source/requirements.rst
@@ -8,14 +8,13 @@ Software Requirements
 
 On the Web node serving OnDemand itself:
 
-- `EPEL repository`_
 - `Software Collections repositories`_
 - `lsof`_
 - `sudo`_
 - `OnDemand repository`_:
     - ondemand-{{ondemand_version}}-1.el7.x86_64.rpm
+
 .. _Software Collections repositories: https://www.softwarecollections.org/en/
-.. _EPEL repository: https://fedoraproject.org/wiki/EPEL
 .. _lsof: https://en.wikipedia.org/wiki/Lsof
 .. _OnDemand repository: https://openondemand.org/
 .. _sudo: https://www.sudo.ws/

--- a/source/requirements.rst
+++ b/source/requirements.rst
@@ -8,33 +8,16 @@ Software Requirements
 
 On the Web node serving OnDemand itself:
 
-- `epel-release`_
-- `centos-release-scl`_
+- `EPEL repository`_
+- `Software Collections repositories`_
 - `lsof`_
 - `sudo`_
-- `ondemand-release-web-latest-1-5.noarch.rpm`_:
-    - cjose-0.6.1-1.el7.x86_64.rpm
-    - cjose-debuginfo-0.6.1-1.el7.x86_64.rpm
-    - cjose-devel-0.6.1-1.el7.x86_64.rpm
-    - httpd24-mod_auth_openidc-2.3.11-1.el7.x86_64.rpm
-    - httpd24-mod_auth_openidc-debuginfo-2.3.11-1.el7.x86_64.rpm
-    - ondemand-apache-{{ondemand_version}}-1.el7.x86_64.rpm
-    - ondemand-git-{{ondemand_version}}-1.el7.x86_64.rpm
-    - ondemand-nginx-1.14.0-2.p5.3.7.el7.x86_64.rpm
-    - ondemand-nginx-debuginfo-1.14.0-2.p5.3.7.el7.x86_64.rpm
-    - ondemand-nginx-filesystem-1.14.0-2.p5.3.7.el7.noarch.rpm
-    - ondemand-nodejs-{{ondemand_version}}-1.el7.x86_64.rpm
-    - ondemand-passenger-5.3.7-2.el7.x86_64.rpm
-    - ondemand-passenger-debuginfo-5.3.7-2.el7.x86_64.rpm
-    - ondemand-passenger-devel-5.3.7-2.el7.x86_64.rpm
-    - ondemand-ruby-{{ondemand_version}}-1.el7.x86_64.rpm
-    - ondemand-runtime-{{ondemand_version}}-1.el7.x86_64.rpm
-    - ondemand-scldevel-{{ondemand_version}}-1.el7.x86_64.rpm
-
-.. _centos-release-scl: https://www.softwarecollections.org/en/
-.. _epel-release: https://fedoraproject.org/wiki/EPEL
+- `OnDemand repository`_:
+    - ondemand-{{ondemand_version}}-1.el7.x86_64.rpm
+.. _Software Collections repositories: https://www.softwarecollections.org/en/
+.. _EPEL repository: https://fedoraproject.org/wiki/EPEL
 .. _lsof: https://en.wikipedia.org/wiki/Lsof
-.. _ondemand-release-web-latest-1-5.noarch.rpm: https://openondemand.org/
+.. _OnDemand repository: https://openondemand.org/
 .. _sudo: https://www.sudo.ws/
 
 And on the Compute node(s):


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/develop/

**Add your description here**

Simplify system requirements. The names for EPEL and SCL were CentOS specific package names so change to just names. The list of packages for OnDemand repo are not requirements, only ondemand package is requirement, rest are either dependencies pulled in by OnDemand package or optional. The list would become out of date very quickly if listing everything in repo.