### PR TITLE
Remove references to rh-git29 and also update repo release RPM paths

### DIFF
--- a/source/app-development/tutorials-passenger-apps/ps-to-quota.rst
+++ b/source/app-development/tutorials-passenger-apps/ps-to-quota.rst
@@ -251,10 +251,6 @@ Run test by running `rake` command and you will see it fail:
 
    ``scl enable ondemand -- rake``
 
-   With SCL, running git commands using ondemand SCL looks like:
-
-   ``scl enable ondemand -- git commit -m "initial commit"``
-
    You can avoid this by loading the SCL packages in your .bashrc or .bash_profile file.
    For example, in my .bash_profile I have:
 

--- a/source/installation/from-source/core-apps.rst
+++ b/source/installation/from-source/core-apps.rst
@@ -33,7 +33,7 @@ Each application has its own dependencies which need to be installed (from eithe
 
   .. note::
 
-    ``scl enable ondemand`` is equivalent to simultaneously enabling: rh-nodejs6 rh-ruby24 rh-git29.
+    ``scl enable ondemand`` is equivalent to simultaneously enabling: rh-nodejs6 rh-ruby24.
 
   .. note::
 

--- a/source/installation/from-source/ood-infrastructure.rst
+++ b/source/installation/from-source/ood-infrastructure.rst
@@ -8,9 +8,9 @@ OnDemand's core infrastructure is stored in a Github repository located at https
   .. code-block:: sh
 
     cd /opt/ood
-    sudo scl enable rh-git29 -- git init
-    sudo scl enable rh-git29 -- git remote add origin https://github.com/osc/ondemand
-    sudo scl enable rh-git29 -- git pull origin master
+    git init
+    git remote add origin https://github.com/osc/ondemand
+    git pull origin master
 
 .. warning::
 

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -86,5 +86,4 @@ software requirements:
 .. _apache http server 2.4: https://www.softwarecollections.org/en/scls/rhscl/httpd24/
 .. _ruby 2.4: https://www.softwarecollections.org/en/scls/rhscl/rh-ruby24/
 .. _node.js 6: https://www.softwarecollections.org/en/scls/rhscl/rh-nodejs6/
-.. _git 2.9: https://www.softwarecollections.org/en/scls/rhscl/rh-git29/
 .. _ohio supercomputer center: https://www.osc.edu/

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -10,7 +10,6 @@ software requirements:
 - `Ruby 2.4`_ with :command:`rake`, :command:`bundler`, and development
   libraries
 - `Node.js 6`_
-- `Git 2.9`_
 
 .. note::
 

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -46,7 +46,7 @@ software requirements:
 
      .. code-block:: sh
 
-        sudo yum install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-1.noarch.rpm
+        sudo yum install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-2.noarch.rpm
 
 #. Install OnDemand and all of its dependencies:
 

--- a/source/release-notes/v1.6-release-notes.rst
+++ b/source/release-notes/v1.6-release-notes.rst
@@ -29,17 +29,9 @@ Upgrading from v1.5
 
 #. Update OnDemand release RPM
 
-   CentOS/RHEL 6
-
    .. code-block:: sh
 
-      sudo yum install -y https://yum.osc.edu/ondemand/1.6/ondemand-release-web-1.6-1.el6.noarch.rpm
-
-   CentOS/RHEL 7
-
-   .. code-block:: sh
-
-      sudo yum install -y https://yum.osc.edu/ondemand/1.6/ondemand-release-web-1.6-1.el7.noarch.rpm
+      sudo yum install -y https://yum.osc.edu/ondemand/1.6/ondemand-release-web-1.6-2.noarch.rpm
 
 #. Update OnDemand
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/develop/

**Add your description here**
