### PR TITLE
add link to ansible role in src directions

### DIFF
--- a/source/installation/from-source.rst
+++ b/source/installation/from-source.rst
@@ -11,6 +11,10 @@ Install From Source
 
 The alternative to installing the core of OnDemand using RPMs is to install from source. This tutorial will assume installation on a CentOS/RHEL 7 base. We will look at how to install the core of OnDemand, while still using some OSC-provided RPMs to ensure a functioning build without having to go into too much detail. Installation on non-RPM-based systems is possible, but installing compatible versions of certain dependencies is left as an exercise for the interested.
 
+  .. tip::
+    If you prefer an automated build and installation procedure, we provide an `Ansible role`_ for that purpose.
+
+.. _Ansible role: https://github.com/osc/ood-ansible
 
 .. note::
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

would be https://osc.github.io/ood-documentation-test/add-ansible-directions/ but forks don't create html pages?

**Add your description here**

Add's a tip that's a link to the ansible role in the build from source directions.