### PR TITLE
fix broken relative link

### DIFF
--- a/source/installation/from-source.rst
+++ b/source/installation/from-source.rst
@@ -7,7 +7,7 @@ Install From Source
 
     Skip to the `next section`_ if installing from RPMs
 
-.. _next section: /installation/modify-system-security.html
+.. _next section: /ood-documentation/master/installation/modify-system-security.html
 
 The alternative to installing the core of OnDemand using RPMs is to install from source. This tutorial will assume installation on a CentOS/RHEL 7 base. We will look at how to install the core of OnDemand, while still using some OSC-provided RPMs to ensure a functioning build without having to go into too much detail. Installation on non-RPM-based systems is possible, but installing compatible versions of certain dependencies is left as an exercise for the interested.
 

--- a/source/installation/from-source.rst
+++ b/source/installation/from-source.rst
@@ -5,9 +5,9 @@ Install From Source
 
   .. note::
 
-    Skip to the `next section`_ if installing from RPMs
+    Skip to the :ref:`modify-system-security` section when installing from RPMs
 
-.. _next section: /ood-documentation/master/installation/modify-system-security.html
+..
 
 The alternative to installing the core of OnDemand using RPMs is to install from source. This tutorial will assume installation on a CentOS/RHEL 7 base. We will look at how to install the core of OnDemand, while still using some OSC-provided RPMs to ensure a functioning build without having to go into too much detail. Installation on non-RPM-based systems is possible, but installing compatible versions of certain dependencies is left as an exercise for the interested.
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/BRANCH-NAME/

This PR modifies a single link on the Install From Source page

https://osc.github.io/ood-documentation/master/installation/from-source.html

The skip to the next section link lands you at a 404:

https://osc.github.io/installation/modify-system-security.html

This PR should update the relative link to redirect the user correctly to

https://osc.github.io/ood-documentation/master/installation/modify-system-security.html