### PR TITLE
add a google analytics tracker to the layout

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,0 +1,13 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+{{ super() }}
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-34776817-3"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-34776817-3');
+</script>
+{% endblock %}


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/add-ga-tracker

This adds a google analytics tracker so we can see how folks navigate our docs.   Note that I want to pull this into master and not develop. After this, we probably want to pull it into some, if not all, release- branches and develop maybe too.
