### PR TITLE
documentation for GE's use of OOD_JOB_NAME_ILLEGAL_CHARS

### DIFF
--- a/source/installation/resource-manager/sge.rst
+++ b/source/installation/resource-manager/sge.rst
@@ -101,9 +101,12 @@ job names like the error below.
 
 ``Unable to read script file because of error: ERROR! argument to -N option must not contain /``
 
-To resolve this set ``OOD_JOB_NAME_ILLEGAL_CHARS`` in the ``/etc/ood/config/apps/dashboard/env`` file.
+To resolve this set ``OOD_JOB_NAME_ILLEGAL_CHARS`` to ``/`` for all OOD applications in the 
+``/etc/ood/profile`` file.
 
 .. code-block:: text
 
-   # /etc/ood/config/apps/dashboard/env
+   # /etc/ood/profile
    OOD_JOB_NAME_ILLEGAL_CHARS="/"
+
+   . /opt/ood/nginx_stage/etc/profile

--- a/source/installation/resource-manager/sge.rst
+++ b/source/installation/resource-manager/sge.rst
@@ -93,3 +93,17 @@ This sets the sh shell to behave like bash and ensures you've sourced your users
             set +o posix
             . ~/.bashrc
             %s
+
+Invalid Job name
+****************
+You're likely to encounter an issue in running batch connect applications complaining about invalid
+job names like the error below.
+
+``Unable to read script file because of error: ERROR! argument to -N option must not contain /``
+
+To resolve this set ``OOD_JOB_NAME_ILLEGAL_CHARS`` in the ``/etc/ood/config/apps/dashboard/env`` file.
+
+.. code-block:: text
+
+   # /etc/ood/config/apps/dashboard/env
+   OOD_JOB_NAME_ILLEGAL_CHARS="/"

--- a/source/installation/resource-manager/sge.rst
+++ b/source/installation/resource-manager/sge.rst
@@ -96,17 +96,16 @@ This sets the sh shell to behave like bash and ensures you've sourced your users
 
 Invalid Job name
 ****************
-You're likely to encounter an issue in running batch connect applications complaining about invalid
+If you encounter an issue in running batch connect applications complaining about invalid
 job names like the error below.
 
 ``Unable to read script file because of error: ERROR! argument to -N option must not contain /``
 
 To resolve this set ``OOD_JOB_NAME_ILLEGAL_CHARS`` to ``/`` for all OOD applications in the 
-``/etc/ood/profile`` file.
+``pun_custom_env`` attribute of the ``/etc/ood/config/nginx_stage.yml`` file.
 
-.. code-block:: text
+.. code-block:: yaml
 
-   # /etc/ood/profile
-   OOD_JOB_NAME_ILLEGAL_CHARS="/"
-
-   . /opt/ood/nginx_stage/etc/profile
+    # /etc/ood/config/nginx_stage.yml
+    pun_custom_env:
+      - OOD_JOB_NAME_ILLEGAL_CHARS: "/"


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/ge-job-names


Docs for #246.  The related tickets mention PBSPro as well, but I tracked that down to [this ticket](https://github.com/OSC/ondemand/issues/341) in which the issue was due to colons in the output path (-o option).  As it stands, this feature only [sanitizes job names](https://github.com/OSC/ondemand/pull/429/files#diff-9ddf794da41002473c7abf3dc34e48d5R242). 

Which is to say, I've only documented this feature as it relates to Grid engine and left PBSPro alone.