### PR TITLE
Improve linux host adapter documentation

### DIFF
--- a/source/installation/resource-manager/linuxhost.rst
+++ b/source/installation/resource-manager/linuxhost.rst
@@ -156,6 +156,20 @@ First update the PAM stack to include the following line:
 
    session     required      pam_exec.so type=open_session /etc/security/limits.sh
 
+This goes into a file used by the ``sshd`` PAM configs which on CentOS/RHEL default to ``/etc/pam.d/password-auth-ac`` and needs to be included in the proper position, after ``pam_systemd.so``. Also set ``pam_systemd.so`` to ``required``:
+
+.. code-block:: none
+   :emphasize-lines: 3,4
+   :linenos:
+
+   session     optional      pam_keyinit.so revoke
+   session     required      pam_limits.so
+   session     required      pam_systemd.so
+   session     required      pam_exec.so type=open_session /etc/security/limits.sh
+   session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+   session     required      pam_unix.so
+   session     optional      pam_sss.so
+
 The following example of ``/etc/security/limits.sh`` is used by OSC on interactive login nodes. Adjust ``MemoryLimit`` and ``CPUQuota`` to meet the needs of your site. See ``man systemd.resource-control``
 
 .. code-block:: bash

--- a/source/installation/resource-manager/linuxhost.rst
+++ b/source/installation/resource-manager/linuxhost.rst
@@ -40,7 +40,7 @@ Launch any software on target host
 ----------------------------------
 
 1. Install on the target host a Singularity base OS image matching the OS of the target host. In the cluster configuration example below we use ``/opt/ood/linuxhost_adapter/centos_7.6.sif`` as the target host is running CentOS7.
-2. Add the cluster configuration file for the target host
+2. See :ref:`resource-manager-linuxhost-cluster-configuration` below to add the cluster configuration file for the target host
 
 This base image is used to provide an unprivileged PID namespace when launching the app. To make the rest of the software installed on the host available to launch within the image, most/all of the host file system is bind-mounted into the running container. For this reason many existing interactive apps will just work when launched by the LinuxHost adapter.
 
@@ -48,7 +48,7 @@ Launch specific application containers
 --------------------------------------
 
 1. Install the specific application containers on the target host.
-2. Add the cluster configuration file for the target host. Specify a default application container for ``singularity_image:`` and ``singularity_bindpath:`` even if you will override it.
+2. See :ref:`resource-manager-linuxhost-cluster-configuration` below to add the cluster configuration file for the target host. Specify a default application container for ``singularity_image:`` and ``singularity_bindpath:`` even if you will override it.
 3. In each interactive app plugin, specify the image to launch and host directories to mount by setting the ``native`` attribute ``singularity_container`` and ``singularity_bindpath``. In interactive app plugins these attributes may be set in the file ``submit.yml``. For example:
 
 
@@ -61,6 +61,7 @@ Launch specific application containers
         singularity_bindpath: /fs,/home
         singularity_container: /usr/local/modules/netbeans/netbeans_2019.sif
 
+.. _resource-manager-linuxhost-cluster-configuration:
 
 Cluster Configuration
 ---------------------

--- a/source/installation/resource-manager/linuxhost.rst
+++ b/source/installation/resource-manager/linuxhost.rst
@@ -1,22 +1,156 @@
 .. _resource-manager-linuxhost:
 
-LinuxHost Adapter
-=================
+Configure LinuxHost Adapter (beta)
+==================================
+
+.. warning:: While we have tested this at OSC, we do not currently use it in a production capacity nor do any other centers as of April 23, 2020. If you are an early adopter of this feature, please let us know on Discourse or by email about your experience and any improvements we can make.
+
+The LinuxHost adapter facilitates launching jobs immediately without using a batch scheduler or resource manager. Use cases for this non-traditional job adapter include:
+
+- Interactive work on login nodes, such as remote desktop or IDE
+- Providing an option to start an interactive session immediately, without any queue time imposed
+- Using OnDemand on systems that do not have a supported scheduler installed
+
+The adapter pieces together several tools to achieve behavior similar to what a scheduler offers:
+
+
+ssh
+  connects from the web node to a configured host such as a login node.
+tmux
+  Specially named ``tmux`` sessions offer the ability to rediscover running jobs
+timeout
+  is used to set a 'walltime' after which the job is killed
+pstree
+  is used to detect the job's parent ``sinit`` process so that it can be killed
+singularity
+  containerization provides a PID namespace without requiring elevated privileges that ensures that all child processes are cleaned up when the job either times out or is killed
+
+.. note:: There are many recipes for managing processes on arbitrary Linux hosts, and we will be exploring others in future development of this adapter.
+
+
+How To Configure The Adapter
+****************************
+
+The adapter and target host can be configured to either:
+
+#. Enable launching any software installed on the target host
+#. Enable launching a specific application container
+
+The cluster configuration can be shared between both strategies and each interactive app plugin individually configured to use the appropriate strategy.
+
+
+Launch any software on target host
+----------------------------------
+
+1. Install on the target host a Singularity base OS image matching the OS of the target host. In the cluster configuration example below we use ``/opt/ood/linuxhost_adapter/centos_7.6.sif`` as the target host is running CentOS7.
+2. Add the cluster configuration file for the target host
+
+This base image is used to provide an unprivileged PID namespace when launching the app. To make the rest of the software installed on the host available to launch within the image, most/all of the host file system is bind-mounted into the running container. For this reason many existing interactive apps will just work when launched by the LinuxHost adapter.
+
+Launch specific application containers
+--------------------------------------
+
+1. Install the specific application containers on the target host.
+2. Add the cluster configuration file for the target host. Specify a default application container for ``singularity_image:`` and ``singularity_bindpath:`` even if you will override it.
+3. In each interactive app plugin, specify the image to launch and host directories to mount by setting the ``native`` attribute ``singularity_container`` and ``singularity_bindpath``. In interactive app plugins these attributes may be set in the file ``submit.yml``. For example:
+
+
+.. code-block:: yaml
+
+   ---
+   batch_connect:
+     template: vnc
+     native:
+        singularity_bindpath: /fs,/home
+        singularity_container: /usr/local/modules/netbeans/netbeans_2019.sif
+
+
+Cluster Configuration
+---------------------
+
+A YAML cluster configuration file for a Linux host looks like:
+
+.. code-block:: yaml
+   :emphasize-lines: 10-
+
+   # /etc/ood/config/clusters.d/owens_login.yml
+   ---
+   v2:
+     metadata:
+       title: "Owens"
+       url: "https://www.osc.edu/supercomputing/computing/owens"
+       hidden: true
+     login:
+       host: "owens.osc.edu"
+     job:
+       adapter: "linux_host"
+       submit_host: "owens.osc.edu"  # This is the head for a login round robin
+       ssh_hosts: # These are the actual login nodes
+         - owens-login01.hpc.osc.edu
+         - owens-login02.hpc.osc.edu
+         - owens-login03.hpc.osc.edu
+       site_timeout: 7200
+       debug: true
+       singularity_bin: /usr/bin/singularity
+       singularity_bindpath: /etc,/media,/mnt,/opt,/run,/srv,/usr,/var,/users
+       singularity_image: /opt/ood/linuxhost_adapter/centos_7.6.sif
+       # Enabling strict host checking may cause the adapter to fail if the user's known_hosts does not have all the roundrobin hosts
+       strict_host_checking: false
+       tmux_bin: /usr/bin/tmux
+
+with the following configuration options:
+
+adapter
+  This is set to ``linux_host``.
+submit_host
+  The target execution host for jobs. May be the head for a login round robin. May also be "localhost".
+ssh_hosts
+ All nodes the submit_host can DNS resolve to.
+site_timeout
+  The number of seconds that a user's job is allowed to run. Distinct from the length of time that a user selects.
+debug
+  When set to ``true`` job scripts are written to ``$HOME/tmp.UUID_tmux`` and ``$HOME/tmp.UUID_sing`` for debugging purposes. When ``false`` those files are written to ``/tmp`` and deleted as soon as they have been read.
+singularity_bin
+  The absolute path to the ``singularity`` executable on the execution host(s).
+singularity_bindpath
+  The comma delimited list of paths to bind mount into the host; cannot simply be ``/`` because Singularity expects certain dot files in its containers' root; defaults to: ``/etc,/media,/mnt,/opt,/run,/srv,/usr,/var,/users``.
+singularity_image
+  The absolute path to the Singularity image used when simply PID namespacing jobs; expected to be a base distribution image with no customizations.
+strict_host_checking
+  When ``false`` the SSH options include ``StrictHostKeyChecking=no`` and ``UserKnownHostsFile=/dev/null`` this prevents jobs from failing to launch.
+tmux_bin
+  The absolute path to the ``tmux`` executable on the execution host(s).
+
 
 .. warning::
 
-   This is an experimental feature right now that may change drastically in the
-   future. So always revisit this documentation after upgrading OnDemand.
+   This adapter was designed with the primary goal of launching installed
+   software on the target host, not launching specific application containers.
+   As a result, even if your use of this adapter is reserved to launching
+   specific application containers, you currently must specify a value in the
+   cluster config for ``singularity_bindpath`` and ``singularity_image``, even
+   if these will be specified in each interactive app plugin.
 
-First Setup cgroups
-********************
+.. note::
+
+  In order to communicate with the execution hosts the adapter uses SSH in
+  ``BatchMode``. The adapter does not take a position on whether authentication
+  is performed by user owned passwordless keys, or host-based authentication;
+  however OSC has chosen to provide `host based authentication
+  <https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Host-based_Authentication>`_
+  to its users.
+
+
+
+Enforce resource limits on the target host
+******************************************
 
 By default the adapter does not limit the user's CPU or memory utilization, only their "walltime". The following are two examples of ways to implement resource limits for the LinuxHost Adapter using cgroups.
 
 Approach #1: Systemd user slices
 --------------------------------
 
-With systemd it is possible to manage the resource limits of user logins through each user's "slice_". The limits applied to a user slice are shared by all processes belonging to that user, this is not a per-job or per-node resource limit but a per-user limit. When setting the limits keep in mind the sum of all user limits is the max potential resource consumption on a single host.
+With systemd it is possible to manage the resource limits of user logins through each user's `slice <https://www.freedesktop.org/software/systemd/man/systemd.slice.html>`_. The limits applied to a user slice are shared by all processes belonging to that user, this is not a per-job or per-node resource limit but a per-user limit. When setting the limits keep in mind the sum of all user limits is the max potential resource consumption on a single host.
 
 First update the PAM stack to include the following line:
 
@@ -82,106 +216,6 @@ Start the necessary services:
    sudo systemctl enable cgconfig
    sudo systemctl enable cgred
 
-How To Configure The Adapter
-****************************
-
-A YAML cluster configuration file for a Linux host looks like:
-
-.. code-block:: yaml
-   :emphasize-lines: 10-
-
-   # /etc/ood/config/clusters.d/owens_login.yml
-   ---
-   v2:
-     metadata:
-       title: "Owens"
-       url: "https://www.osc.edu/supercomputing/computing/owens"
-       hidden: true
-     login:
-       host: "owens.osc.edu"
-     job:
-       adapter: "linux_host"
-       submit_host: "owens.osc.edu"  # This is the head for a login round robin
-       ssh_hosts: # These are the actual login nodes
-         - owens-login01.hpc.osc.edu
-         - owens-login02.hpc.osc.edu
-         - owens-login03.hpc.osc.edu
-       site_timeout: 7200
-       debug: true
-       singularity_bin: /usr/bin/singularity
-       singularity_bindpath: /etc,/media,/mnt,/opt,/run,/srv,/usr,/var,/users
-       singularity_image: /opt/ood/linuxhost_adapter/centos_7.6.sif
-       # Enabling strict host checking may cause the adapter to fail if the user's known_hosts does not have all the roundrobin hosts
-       strict_host_checking: false  
-       tmux_bin: /usr/bin/tmux
-
-with the following configuration options:
-
-adapter
-  This is set to ``linux_host``.
-submit_host
-  The target execution host for jobs. May be the head for a login round robin. May also be "localhost".
-ssh_hosts
- All nodes the submit_host can DNS resolve to.
-site_timeout
-  The number of seconds that a user's job is allowed to run. Distinct from the length of time that a user selects.
-debug
-  When set to ``true`` job scripts are written to ``$HOME/tmp.UUID_tmux`` and ``$HOME/tmp.UUID_sing`` for debugging purposes. When ``false`` those files are written to ``/tmp`` and deleted as soon as they have been read.
-singularity_bin
-  The absolute path to the ``singularity`` executable on the execution host(s).
-singularity_bindpath
-  The comma delimited list of paths to bind mount into the host; cannot simply be ``/`` because Singularity expects certain dot files in its containers' root; defaults to: ``/etc,/media,/mnt,/opt,/run,/srv,/usr,/var,/users``.
-singularity_image
-  The absolute path to the Singularity image used when simply PID namespacing jobs; expected to be a base distribution image with no customizations.
-strict_host_checking
-  When ``false`` the SSH options include ``StrictHostKeyChecking=no`` and ``UserKnownHostsFile=/dev/null`` this prevents jobs from failing to launch.
-tmux_bin
-  The absolute path to the ``tmux`` executable on the execution host(s).
-
-.. note::
-
-  In order to communicate with the execution hosts the adapter uses SSH in ``BatchMode``. The adapter does not take a position on whether authentication is performed by user owned passwordless keys, or host-based authentication; however OSC has chosen to provide `host based authentication`_ to its users.
-
-An Example User Story
-*********************
-
-As an HPC user working in ``R`` I want to be able to be able to launch RStudio so that I can use it as an IDE; if I am told that my resources are limited I will not run anything that takes up more than N CPUs, X memory, or Z hours.
-
-A Non-traditional Job Launcher
-******************************
-
-The LinuxHost adapter facilitates launching jobs immediately without using a traditional scheduler or resource manager. Use cases for this non-traditional job adapter include:
-
-- Launching desktop environments
-- Launching code editors
-- Using OnDemand on systems that do not have a supported scheduler installed
-
-The adapter pieces together several common Linux/HPC technologies to achieve behavior similar to what a scheduler offers.
-
-- ``ssh`` connects from the web node to a configured host such as a login node.
-- Specially named ``tmux`` sessions offer the ability to rediscover running jobs
-- ``singularity`` containerization provides a PID namespace without requiring elevated privileges that ensures that all child processes are cleaned up when the job either times out or is killed
-- ``timeout`` is used to set a 'walltime' after which the job is killed
-- ``pstree`` is used to detect the job's parent ``sinit`` process so that it can be killed
-
-A Non-traditional Use of Singularity
-************************************
-
-Singularity is a containerization technology similar to Docker which can be safely used on multi-tenant systems. The LinuxHost adapter can use these containers in two different ways.
-
-The first way to use Singularity is to simply use it as an unprivileged PID namespace. In this case most/all of the host file system is bind-mounted into the running container and the fact that the job is inside a container should not be visible. For this reason many existing BatchConnect applications will just work when launched by the LinuxHost adapter. A base CentOS image should be installed on the target compute hosts, we suggest ``/opt/ood/linuxhost_adapter/$IMAGE_NAME.sif`` but any path may be configured.
-
-The second way to use Singularity is the designed use of containers: launch a self contained applications with only the bare minimum host directories mounted into the running container. In this method you would likely want access to application inputs, an output directory and possibly nothing else. A job's container is set by providing values for the ``native`` attribute ``singularity_container`` and ``singularity_bindpath``. In Batch Connect applications these attributes may be set in the file ``submit.yml``:
-
-
-.. code-block:: yaml
-   
-   ---
-   batch_connect:
-     template: vnc
-     native:
-        singularity_bindpath: /etc,/media,/mnt,/opt,/run,/srv,/usr,/var,/fs,/home
-        singularity_container: /usr/local/modules/netbeans/netbeans_2019.sif
 
 Troubleshooting
 ***************
@@ -263,8 +297,9 @@ Again, mounting ``var`` fixed this error too.
 
 .. note::
 
-   Subsequent versions of the adapter are expected to use unshare_ for PID namespacing as the default method instead of Singularity. Singularity will continue to be supported.
+   Subsequent versions of the adapter are expected to use `unshare <http://man7.org/linux/man-pages/man1/unshare.1.html>`_ for PID namespacing as the default method instead of Singularity. Singularity will continue to be supported.
 
-.. _host based authentication: https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Host-based_Authentication
-.. _slice: https://www.freedesktop.org/software/systemd/man/systemd.slice.html
-.. _unshare: man7.org/linux/man-pages/man1/unshare.1.html
+
+
+
+

--- a/source/installation/resource-manager/linuxhost.rst
+++ b/source/installation/resource-manager/linuxhost.rst
@@ -28,9 +28,6 @@ singularity
 .. note:: There are many recipes for managing processes on arbitrary Linux hosts, and we will be exploring others in future development of this adapter.
 
 
-How To Configure The Adapter
-****************************
-
 The adapter and target host can be configured to either:
 
 #. Enable launching any software installed on the target host
@@ -143,12 +140,12 @@ tmux_bin
 
 
 Enforce resource limits on the target host
-******************************************
+------------------------------------------
 
 By default the adapter does not limit the user's CPU or memory utilization, only their "walltime". The following are two examples of ways to implement resource limits for the LinuxHost Adapter using cgroups.
 
 Approach #1: Systemd user slices
---------------------------------
+................................
 
 With systemd it is possible to manage the resource limits of user logins through each user's `slice <https://www.freedesktop.org/software/systemd/man/systemd.slice.html>`_. The limits applied to a user slice are shared by all processes belonging to that user, this is not a per-job or per-node resource limit but a per-user limit. When setting the limits keep in mind the sum of all user limits is the max potential resource consumption on a single host.
 
@@ -175,7 +172,7 @@ The following example of ``/etc/security/limits.sh`` is used by OSC on interacti
    fi
 
 Approach #2: libcgroup cgroups
-------------------------------
+..............................
 
 The libcgroup cgroups rules and configurations are a per-group resource limit where the group is defined in the examples at ``/etc/cgconfig.d/limits.conf``. The following examples limit resources of all tmux processes launched for the LinuxHost Adapter so they all share 700 CPU shares and 64GB of RAM. This requires setting ``tmux_bin`` to a wrapper script that in this example will be ``/usr/local/bin/ondemand_tmux``.
 
@@ -218,10 +215,11 @@ Start the necessary services:
 
 
 Troubleshooting
-***************
+---------------
 
 Undetermined state
-------------------
+..................
+
 Your job can be in an 'undetermined state' because you haven't listed all the ``ssh_hosts``.
 ``ssh_hosts`` should be *anything* the ``submit_host`` can DNS resolve to. You submit your
 job the ``submit_host``, but OnDemand is going to poll the ``ssh_hosts`` for your job and
@@ -245,7 +243,7 @@ by the 'job name') so the adapter now cannot find my job.
 .. figure:: /images/linux_host_undetermined.png
 
 error while loading shared libraries
-------------------------------------
+....................................
 
 The default mounts for singularity are ``'/etc,/media,/mnt,/opt,/srv,/usr,/var,/users'``.  It's likely
 either you've overwritten this with too few mounts (like /lib, /opt or /usr) or your container lacks
@@ -255,7 +253,7 @@ If the library exists on the host, consider mounting it into the container. Othe
 the container definition and rebuild the container.
 
 The job just exists with no errors.
------------------------------------
+...................................
 
 This is where turning debug on with ``debug: true`` is really going to come in handy.
 
@@ -278,7 +276,8 @@ the issue.
 
 
 D-Bus errors
-------------
+............
+
 Maybe you've seen something like below.  Mounting ``/var`` into the container will likely fix the issue.
 
 .. code-block:: shell


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/linux_host_adapter_updates/installation/resource-manager/linuxhost.html

- Ensure that overview of adapter is at the top including the dependencies front and center
- Specify as beta and warn that it is not yet in production use at OSC
- Organize configuration of adapter by introducing the two ways to use it, and steps to configure for each