### PR TITLE
Fix link to Software Requirements on Customize Attributes page for the RStudio Interactive Apps tutorial

### DIFF
--- a/source/app-development/tutorials-interactive-apps/add-rstudio/customize-attributes.rst
+++ b/source/app-development/tutorials-interactive-apps/add-rstudio/customize-attributes.rst
@@ -3,7 +3,7 @@
 Customize Attributes
 ====================
 
-Now we will customize the app to work on a given cluster. Be sure that you walk through :ref:`app-development-tutorials-interactive-apps-add-jupyter-software-requirements` for the given cluster ahead of time.
+Now we will customize the app to work on a given cluster. Be sure that you walk through :ref:`app-development-tutorials-interactive-apps-add-rstudio-software-requirements` for the given cluster ahead of time.
 
 The main responsibility of the ``form.yml`` file (:ref:`app-development-interactive-form`) located in the root of the app is for defining the attributes (their values or HTML form elements) used when generating the batch script.
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/develop/app-development/tutorials-interactive-apps/add-rstudio/customize-attributes.html

For the RStudio Interactive Apps tutorial, the link on the Customize Attributes page to Software Requirements points to the Jupyter tutorial. This PR updates it to point to the RStudio tutorial.