### PR TITLE
Document browser requirements

### DIFF
--- a/source/requirements.rst
+++ b/source/requirements.rst
@@ -43,3 +43,22 @@ The Passenger apps that make up the core of OnDemand (that NGINX is configured w
 Another sizing factor that has impacted us in the past is the size of the ``/tmp`` partition.  We have had incidents where ``/tmp`` is exhausted and so have increased the size from 20GB to 50GB.
 
 .. _OSC: https://osc.edu
+
+Browser Requirements
+--------------------
+
+.. warning::
+
+    No IE11 support. If you are a site that requires IE11 support and are willing to contribute developer time to the project to support this, please reach out to us.
+
+To have the best experience using OnDemand, use the latest versions of `Google Chrome`_, `Mozilla Firefox`_ or `Microsoft Edge`_.
+Use any modern browser that supports ECMAScript 2016.
+
+Google Chrome has the widest range of support since the :doc:`applications/shell` uses ``hterm.js`` which is supported officially by Google.
+Chrome currently is the only web browser that supports the copy and paste functionality in ``noVNC``.
+
+Sites have reported problems with Safari when using the :doc:`applications/shell` or ``noVNC``. Safari is also known to cause problems with WebSockets and Basic Auth.
+
+.. _`Google Chrome`: https://www.google.com/chrome/
+.. _`Mozilla Firefox`: https://www.mozilla.org/en-US/firefox/new/
+.. _`Microsoft Edge`: https://www.microsoft.com/en-us/edge

--- a/source/requirements.rst
+++ b/source/requirements.rst
@@ -55,7 +55,8 @@ To have the best experience using OnDemand, use the latest versions of `Google C
 Use any modern browser that supports ECMAScript 2016.
 
 Google Chrome has the widest range of support since the :doc:`applications/shell` uses ``hterm.js`` which is supported officially by Google.
-Chrome currently is the only web browser that supports the copy and paste functionality in ``noVNC``.
+Chrome currently is the only web browser that natively supports the copy and paste functionality in ``noVNC``.
+Other browsers can do copy and pasting manually through the ``noVNC`` tool drawer.
 
 Sites have reported problems with Safari when using the :doc:`applications/shell` or ``noVNC``. Safari is also known to cause problems with WebSockets and Basic Auth.
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/browser-compatibility/requirements.html#browser-requirements

Closes #333.

Add documentation for browser requirements.

![image](https://user-images.githubusercontent.com/6081892/90549089-f9f3cf00-e15b-11ea-8a4d-eaba44b071e7.png)