### PR TITLE
Rename Reference to Configuration Reference

### DIFF
--- a/source/reference.rst
+++ b/source/reference.rst
@@ -1,7 +1,7 @@
 .. _reference:
 
-Reference
-=========
+Configuration Reference
+=======================
 
 This is reference documentation for all the configuration files and commands that
 make up the Open OnDemand infrastructure.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/configuration-reference/

`Configuration Reference` is more descriptive than `Reference`

<img src="https://user-images.githubusercontent.com/6081892/90561282-78596c80-e16e-11ea-93d1-a4198f698818.png" width=300>