### PR TITLE
Document removal of Safari Basic Auth alert

### DIFF
--- a/source/release-notes/v1.8-release-notes.rst
+++ b/source/release-notes/v1.8-release-notes.rst
@@ -19,6 +19,7 @@ Highlights in 1.8:
 - `Ability to add additional info to batch connect app`_
 - `Support for SVG logos`_
 - `Environment variable name changes`_
+- `Removed Safari compatibility alert for Basic Auth`_
 
 Special thanks
 --------------
@@ -137,3 +138,8 @@ Environment variable name changes
 
 .. _dex: https://github.com/dexidp/dex
 .. _mod_auth_openidc: https://github.com/zmartzone/mod_auth_openidc
+
+Removed Safari compatibility alert for Basic Auth
+.................................................
+
+OnDemand uses Dex for authentication by default in version 1.8, the alert on the Dashboard about Basic Auth and WebSocket issues in Safari users was removed.

--- a/source/release-notes/v1.8-release-notes.rst
+++ b/source/release-notes/v1.8-release-notes.rst
@@ -6,6 +6,7 @@ v1.8 Release Notes
 Highlights in 1.8:
 
 - `Default authentication is now handled by Dex`_
+- `Removed Safari compatibility alert for Basic Auth`_
 - `Support mod_auth_openidc configuration via ood-portal-generator`_
 - `Beta CCQ Scheduler support`_
 - `Retain completed jobs panel for debugging`_
@@ -19,7 +20,6 @@ Highlights in 1.8:
 - `Ability to add additional info to batch connect app`_
 - `Support for SVG logos`_
 - `Environment variable name changes`_
-- `Removed Safari compatibility alert for Basic Auth`_
 
 Special thanks
 --------------
@@ -95,6 +95,11 @@ Default authentication is now handled by Dex
 The default authentication mechanism for OnDemand is now using the OIDC provider `Dex`_.  The Dex authentication will replace Apache's Basic Auth.  Sites wishing to continue using LDAP authentication or other forms of Basic Auth are recommended to configure Dex.
 See :ref:`Dex Authentication <authentication-dex>` for details on OnDemand Dex.
 
+Removed Safari compatibility alert for Basic Auth
+.................................................
+
+OnDemand uses Dex for authentication by default in version 1.8, the alert on the Dashboard about Basic Auth and WebSocket issues in Safari users was removed.
+
 Support mod_auth_openidc configuration via ood-portal-generator
 ...............................................................
 
@@ -138,8 +143,3 @@ Environment variable name changes
 
 .. _dex: https://github.com/dexidp/dex
 .. _mod_auth_openidc: https://github.com/zmartzone/mod_auth_openidc
-
-Removed Safari compatibility alert for Basic Auth
-.................................................
-
-OnDemand uses Dex for authentication by default in version 1.8, the alert on the Dashboard about Basic Auth and WebSocket issues in Safari users was removed.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/basic-auth-alert/

Update release notes, document removal of Safari Basic Auth alert.

Closes #343.
