### PR TITLE
Add link to Browser Requirements in changelog

### DIFF
--- a/source/release-notes/v1.8-release-notes.rst
+++ b/source/release-notes/v1.8-release-notes.rst
@@ -267,7 +267,7 @@ Drop IE 11 support
 .. warning::
   No IE 11 support. If you are a site that requires IE 11 support and are willing to contribute developer time to the project to support this, please reach out to us.
 
-IE 11 support was officially dropped. See Browser Requirements.
+IE 11 support was officially dropped. See :ref:`Browser Requirements <browser-requirements>`.
 
 Added Sinatra RubyGems into ondemand-gems for other apps to use
 ...............................................................

--- a/source/requirements.rst
+++ b/source/requirements.rst
@@ -47,9 +47,11 @@ Another sizing factor that has impacted us in the past is the size of the ``/tmp
 Browser Requirements
 --------------------
 
+.. _browser-requirements:
+
 .. warning::
 
-    No IE11 support. If you are a site that requires IE11 support and are willing to contribute developer time to the project to support this, please reach out to us.
+    No IE 11 support. If you are a site that requires IE 11 support and are willing to contribute developer time to the project to support this, please reach out to us.
 
 To have the best experience using OnDemand, use the latest versions of `Google Chrome`_, `Mozilla Firefox`_ or `Microsoft Edge`_.
 Use any modern browser that supports ECMAScript 2016.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/update-browser-req-link/release-notes/v1.8-release-notes.html#drop-ie-11-support

Add link to Browser Requirements in changelog