### PR TITLE
Add HTML meta tags for Algolia DocSearch

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -2,6 +2,10 @@
 
 {% block extrahead %}
 {{ super() }}
+<meta name="docsearch:language" content="en"/>
+<meta name="docsearch:version" content="1.8.0"/>
+<meta name="docsearch:branch" content="latest"/>
+
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-34776817-3"></script>
 <script>
   window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
This PR is the scaffolding for a successful Algolia DocSearch deployment! We recently got approved for a [DocSearch](https://docsearch.algolia.com/) account since Open OnDemand is open source.

**TLDR: We do not want to return search results from version 1.0 with `latest`**

This PR needs to be merged into `latest` because Algolia scrapes `https://osc.github.io/ood-documentation/master/` every 24 hours. The JavaScript code to enable DocSearch looks like this:
```js
docsearch({
  apiKey: PUBLIC_API_KEY,
  indexName: 'osc_ood',
  inputSelector: '#rtd-search-form input[type=text]',
  debug: false,
  algoliaOptions: {
    hitsPerPage: 6,
    facetFilters: [
      'version:1.8.0'
    ]
  },
  custom_settings: {
    attributesForFaceting: ['language', 'version', 'branch']
  },
})
```

DocSearch specifically looks for meta tags named `docsearch:TAG_NAME` and adds it to the search index so results can be filtered based on tags. `facetFilters` is the important bit here, we don't have the following global meta tags deployed on `latest`:

```html
<meta name="docsearch:language" content="en"/>
<meta name="docsearch:version" content="1.8.0"/>
<meta name="docsearch:branch" content="latest"/>
```

Once those are added and Algolia re-scrapes the documentation, then I can introduce the PR that is behind the demos.

**Why we want DocSearch:**
- Free, if we go over the limits then we can self host our own DocSearch Docker image. See [DocSearch FAQ](https://docsearch.algolia.com/docs/faq/).
- Algolia is amazing, look at the screenshot below for example. Typo tolerance will be great for searches.
- Inline and instant search, look at the [Video Demo (20s)](https://streamable.com/4wxy5u).

**Screenshot:**

<img src="https://user-images.githubusercontent.com/6081892/91525953-95a9db80-e8d0-11ea-9aaa-2cedfd53d992.png" width=500>

**Video Demo (20s):** https://streamable.com/4wxy5u