### PR TITLE
Revert "Document Dex for EL8"

### DIFF
--- a/source/authentication/dex.rst
+++ b/source/authentication/dex.rst
@@ -10,12 +10,6 @@ Installing OnDemand Dex package
 
 First the OnDemand yum repos must be enabled, see :ref:`install-software`.
 
-** RHEL/CentOS 8 only** The ``mod_auth_openidc`` module must be enabled with DNF:
-
-   .. code-block:: sh
-
-      sudo dnf module enable mod_auth_openidc:2.3
-
 Install the ``ondemand-dex`` RPM:
 
    .. code-block:: sh

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -49,14 +49,6 @@ software requirements:
 
 #. (Optional) Install :ref:`authentication-dex` package
 
-   .. warning::
-
-      The ``mod_auth_openidc`` DNF module must be enabled on **RHEL/CentOS 8 only**
-
-      .. code-block:: sh
-
-         sudo dnf module enable mod_auth_openidc:2.3
-
    .. note::
 
       If authenticating against LDAP or wishing to evaluate OnDemand using `ood` user, you must install `ondemand-dex`.


### PR DESCRIPTION
This reverts commit 6c7e36042f88f2ca81196ddd501a5b7f8a95a1d4.

**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/develop/

**Add your description here**

Users can NOT install mod_auth_openidc from RHEL/CentOS as it's too old to support config options we specify.  They need to use the version we build.
