### PR TITLE
Fix Keycloak Duo docs to include login template

### DIFF
--- a/source/authentication/duo-2fa-with-keycloak.rst
+++ b/source/authentication/duo-2fa-with-keycloak.rst
@@ -35,12 +35,14 @@ Install Keycloak Duo SPI
       cd ../../..
       mvn clean test package
 
-#. Copy the JAR file to Keycloak and instruct Keycloak to install the SPI
+#. Copy the JAR file and necessary template files to Keycloak and instruct Keycloak to install the SPI
 
    .. code::
 
       sudo install -o keycloak -g keycloak -m 0644 target/keycloak-duo-spi-jar-with-dependencies.jar \
         /opt/keycloak-9.0.0/standalone/deployments/keycloak-duo-spi-jar-with-dependencies.jar
+      sudo install -o keycloak -g keycloak -m 0644 src/main/resources/duo-mfa.ftl \
+        /opt/keycloak-9.0.0/themes/base/login/duo-mfa.ftl
       sudo install -o keycloak -g keycloak -m 0644 /dev/null \
         /opt/keycloak-9.0.0/standalone/deployments/keycloak-duo-spi-jar-with-dependencies.jar.dodeploy
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/develop/

**Add your description here**

Issue reported on Discourse: https://discourse.osc.edu/t/bug-found-following-docs-on-keycloak-with-duo-integration/1115?u=tdockendorf