### PR TITLE
Header security 1.8

### DIFF
--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -171,23 +171,23 @@ Configure General Options
             - '192.168.1..*'
             - '10.0.0.1'
 
-.. describe:: security_disable_frames (Boolean)
+.. describe:: security_csp_frame_ancestors (Boolean)
 
-     Set Header Content-Security-Policy to disallow OnDemand beind loaded in an iFrame.
+     Set Header Content-Security-Policy frame-ancestors.
 
      Default
-       Set Content-Security-Policy
+       Set Content-Security-Policy frame-ancestors to servername
 
        .. code-block:: yaml
 
-           security_disable_frames: true
+           security_csp_frame_ancestors: https://ondemand.example.com
 
      Example
        Disable Content-Security-Policy header
 
        .. code-block:: yaml
 
-          security_disable_frames: false
+          security_csp_frame_ancestors: false
 
 .. describe:: security_strict_transport (Boolean)
 

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -171,6 +171,42 @@ Configure General Options
             - '192.168.1..*'
             - '10.0.0.1'
 
+.. describe:: security_disable_frames (Boolean)
+
+     Set Header Content-Security-Policy to disallow OnDemand beind loaded in an iFrame.
+
+     Default
+       Set Content-Security-Policy
+
+       .. code-block:: yaml
+
+           security_disable_frames: true
+
+     Example
+       Disable Content-Security-Policy header
+
+       .. code-block:: yaml
+
+          security_disable_frames: false
+
+.. describe:: security_strict_transport (Boolean)
+
+     Set Header Strict-Transport-Security to help enforce SSL
+
+     Default
+       Set Strict-Transport-Security if SSL is defined for OnDemand
+
+       .. code-block:: yaml
+
+           security_strict_transport: true
+
+     Example
+       Disable Strict-Transport-Security header
+
+       .. code-block:: yaml
+
+          security_strict_transport: false
+
 .. describe:: lua_root (String)
 
      the root directory where the Lua handler code resides


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/header-security-1.8/

OK this really does back port this to 1.8.
