### PR TITLE
docs for manifest files and the 2.0 RN item for the same

### DIFF
--- a/source/app-development/interactive.rst
+++ b/source/app-development/interactive.rst
@@ -8,7 +8,8 @@ currently provided for all Open OnDemand applications but requires further
 :ref:`app-development-interactive-setup`.
 
 An Interactive App is a :ref:`dashboard` plugin that follows a custom
-file/directory structure and API that can be described by the four stages:
+file/directory structure and API that can be described by the five stages:
+:ref:`app-development-manifest`
 :ref:`app-development-interactive-form`,
 :ref:`app-development-interactive-template`,
 :ref:`app-development-interactive-submit`, and
@@ -31,6 +32,7 @@ Each of these files/directories are described below in their respective stage.
    :maxdepth: 3
    :caption: Stages of an Interactive App
 
+   interactive/manifest
    interactive/form
    interactive/template
    interactive/submit

--- a/source/app-development/interactive/manifest.rst
+++ b/source/app-development/interactive/manifest.rst
@@ -1,0 +1,48 @@
+.. _app-development-manifest:
+
+Manifest yml files
+==================
+
+Every app (interactive and passenger) needs a ``manifest.yml`` file to describe it
+to the Open OnDemand platform.
+
+.. code:: yaml
+
+  ---
+  name: My Cool Biology App
+  category: Interactive Apps
+  subcategory: Biology
+  role: batch_connect
+  description: |
+    This is a multi-line description that will be shown throughout the
+    dashboard.
+  # metadata:
+  #   field_of_science: botany
+
+name
+  The name of the app. This will be shown in menu bars and on icons.
+category
+  The category of the app. This is used to group apps in navigation menus.
+subcategory
+  The subcategory of the app. This is used to group apps within the 
+  navigation menu lists.
+role
+  The role of the app. Here ``batch_connect`` has special meaning to Open
+  OnDemand and is required to indicate it's a batch connect app. Otherwise
+  it's assumed to be a Passenger app.
+description
+  The description of the app. This will be used for additional text when hovering
+  over icons.
+icon (Optional)
+  Apps default to look for an icon.png or icon.svg in their root directory,
+  but this overrides that to specify the icon.
+url (Optional)
+  The url of the application. By default this is generated dynamically but
+  can be overridden.
+metadata (Optional)
+  These are key value pairs you can add to apps for extra grouping capabilities.
+new_window (Optional)
+  A boolean (``true`` or ``false``) flag to toggle if the app should open a new
+  window when clicked.
+
+

--- a/source/release-notes/v2.0-release-notes.rst
+++ b/source/release-notes/v2.0-release-notes.rst
@@ -133,6 +133,8 @@ See the :ref:`documentation on customizing dashboard layouts <dashboard_custom_l
 Adding metadata to app manifests
 ................................
 
+App manifest files now allow for metedata fields for grouping and diplay in the all apps table.
+See :ref:`documentation on manifest files <app-development-manifest>` for more details.
 
 Shell app now has themes
 ........................


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/manifest-docs/

Add documentation on manifest files (because that didn't exist before?!) and a section in the 2.0 RNs about the new features around them.

Fixes #488
