### PR TITLE
more detailed highlight & prioritize files app

### DIFF
--- a/source/release-notes/v2.0-release-notes.rst
+++ b/source/release-notes/v2.0-release-notes.rst
@@ -3,16 +3,20 @@
 v2.0 Release Notes
 ==================
 
+.. warning::
+
+   There are some breaking changes in 2.0. See the upgrade directions below for details.
+
+
 Highlights in 2.0:
 
-- `Breaking Changes`_
-- `Pinning apps to the dashboard`_
-- `Customizable layouts in the dashboard`_
+- `Pinned Apps: Enhanced app launch interface using large app icons on the dashboard`_
+- `Custom dashboard widgets and layout`_
+- `New File Manager app`_
+- `Tighter integration between the Dashboard, Active Jobs, and Files apps`
 - `Adding metadata to app manifests`_
 - `Shell app now has themes`_
 - `Configurations in an ondemand.d directory`_
-- `ActiveJobs now a part of the dashboard`_
-- `New File Manager app`_
 - `Changes in All Apps page layout`_
 - `ERB formats for Message of the day`_
 - `Dependency updates`_
@@ -23,15 +27,11 @@ Upgrading from v1.8
 Breaking Changes
 ................
 
-.. warning::
-
-   There are some breaking changes in 2.0 that you'll need to work through to upgrade.
-
 
 No longer providing ood_auth_map.regex
 **************************************
 
-2.0 no longer provides ``/opt/ood/ood_auth_map/bin/ood_auth_map.regex`` the 1.8- default 
+2.0 no longer provides ``/opt/ood/ood_auth_map/bin/ood_auth_map.regex`` the 1.8- default
 ``user_map_cmd`` in ``ood_portal.yml``.
 
 Most sites should be able to use ``user_map_match`` instead.  You can still use
@@ -52,7 +52,7 @@ each other, so passenger apps will also need to update their bundler dependencie
 ActiveJobs configuration changes
 ********************************
 
-Because `ActiveJobs now a part of the dashboard`_ configuration files are no longer
+Because ActiveJobs now integrated with the Dashboard app, configuration files are no longer
 being read from ``/etc/ood/config/apps/activejobs``.
 
 If you have initializers here in this directory, they need to move to
@@ -65,9 +65,13 @@ this now needs to be ``ActiveJobs::Filter``.
 Files app configuration changes
 ********************************
 
-Because there's a `new file manager app`_ that's a part of the dashboard, so configurations
+Because Files app is now integrated with the Dashboard app, configurations
 in ``/etc/ood/config/apps/files`` need to move to ``/etc/ood/config/apps/dashboard`` for
 them to take effect.
+
+
+Upgrade directions
+..................
 
 .. warning::
 
@@ -171,15 +175,17 @@ them to take effect.
 Details
 -------
 
-Pinning apps to the dashboard
-.............................
+Pinned Apps: Enhanced app launch interface using large app icons on the dashboard
+.................................................................................
 
 See the :ref:`documentation on pinning apps to the dashboard <dashboard_pinned_apps>` for details.
 
-Customizable layouts in the dashboard
-.....................................
+Custom dashboard widgets and layout
+...................................
+
 
 See the :ref:`documentation on customizing dashboard layouts <dashboard_custom_layout>` for details.
+
 
 Adding metadata to app manifests
 ................................
@@ -203,24 +209,31 @@ We've added an ondemand.d directory to start moving configurations there. Some n
 See :ref:`the documentation for the ondemand.d configurations <ondemand-d-ymls>` for all the
 available configurations.
 
-ActiveJobs now a part of the dashboard
-......................................
+Tighter integration between the Dashboard, Active Jobs, and Files apps
+......................................................................
 
-ActiveJobs is now a part of the dashboard. The URL has changed, but redirects from the old
-URL should still work in case sites have this saved somewhere.
+In OnDemand 1.8, the Dashboard, Active Jobs, Files, and File Editor apps were all served by separate
+Passenger application processes. These are all now served by a single Passenger application process per user.
 
-The primary benefit to users will be that the navbar is visible in this app now.
+This change has the following effects:
 
-However you should view `ActiveJobs configuration changes`_ for the breaking changes this
-introduced.
+- The URL has changed, but redirects from the old URLs should still work for backwards compatibilty.
+- The navbar and branding across the dashboard is visible in Active Jobs and File Editor
+- the Active Jobs and Files apps both load without opening a new window
+- the Active Jobs and Files apps load much faster than before
+
+.. warning::
+
+   Configuration for Active Jobs and Files apps have changed slightly and need to be updated for 2.0.
+   See `Breaking Changes`_ above for details.
+
 
 New File Manager app
 ....................
 
 2.0 released with a new File manager application.  This looks and feels differently than
-the previous version, but should have the same functionality.  The previous version was a
-dependency not created or managed by the maintainers of Open OnDemand, and so it was hard
-to add features to and keep up to date.
+the previous version, but has similar functionality.  The previous version was a fork of
+a third party app that was difficult to maintain.
 
 See the `files app configuration changes`_ for any changes you'll need to update to the
 configurations of this new app.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/release_2.0_notes_changes/

- instead of having "Breaking Changes" as a highlight, just moved the warning to the top of the page
- reworded Pinned Apps and Custom widgets highlight titles to attempt to better describe what they are
- reworded section on integrating Active Jobs into the dashboard to also include the other newly integrated apps in the same section
- added missing "Upgrade directions" header after the "Breaking changes" header

Note: there are a few places that could be made links that do not. Since I don't have a lot of time instead of adding review comments on that just consider doing it!

More to  come in separate PRs. Generally, we should expand the sections of the release notes so that they at least contain descriptions as or more verbose than https://discourse.osc.edu/t/announcing-pre-release-of-open-ondemand-2-0/1450

But I think we should consider going a little further with this. For example, we could reiterate some of the goals of the features (outlined in the cards https://trello.com/b/ksr1g141/open-ondemand-ideas-and-dev) and how those are accomplished.

Maybe Buffalo would let us use their screenshot :-).