### PR TITLE
reinforce that lua patterns are not regular expressions

### DIFF
--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -273,7 +273,10 @@ Configure General Options
    for ``user_map_cmd`` above. match has precedence over cmd if they're both
    configured.
 
-   See the `documentation on lua patterns`_ for details.
+   Note that lua patterns are not regular expressions. So boolean OR matches
+   like ``|`` for example are not supported. See the `documentation on lua patterns`_
+   for details more.
+
    You can test your configuration out in a lua shell like so:
 
    .. code-block:: lua

--- a/source/release-notes/v2.0-release-notes.rst
+++ b/source/release-notes/v2.0-release-notes.rst
@@ -31,11 +31,19 @@ Breaking Changes
 No longer providing ood_auth_map.regex
 **************************************
 
-2.0 no longer provides ``/opt/ood/ood_auth_map/bin/ood_auth_map.regex`` the 1.8- default
+2.0 no longer provides ``/opt/ood/ood_auth_map/bin/ood_auth_map.regex``, the 1.8- default
 ``user_map_cmd`` in ``ood_portal.yml``.
 
 Most sites should be able to use ``user_map_match`` instead.  You can still use
 ``user_map_cmd``, only you'll have to write your own in a language of your choice.
+
+
+.. warning::
+
+   lua patterns may not be sufficient because they are not regular expressions. For example
+   they do not support boolean OR ``|`` operators. If you need such functionality you may
+   find python, perl, ruby (SCL or system installed) or even bash commands that suite your
+   needs.
 
 See the :ref:`documentation on user_map_match <ood-portal-generator-user-map-match>`
 for more information on it.


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/more-lua-docs/

Fixes #511 by reinforcing that lua patterns are not regular expressions.
