### PR TITLE
add scl-ruby removal to 2.0 RNs

### DIFF
--- a/source/release-notes/v2.0-release-notes.rst
+++ b/source/release-notes/v2.0-release-notes.rst
@@ -54,7 +54,7 @@ SCL Ruby no longer available to apache
 **************************************
 
 Related to the ood_auth_map.regex change above, apache no longer relies on the SCL version
-of Ruby.  This means that Fuby 2.7 is unavailable to apache and consequently any ``user_map_cmd``
+of Ruby.  This means that Ruby 2.7 is unavailable to apache and consequently any ``user_map_cmd``
 you employ.
 
 Should you need Ruby 2.7 in any commands or scripts that apache calls, the best mitigation is

--- a/source/release-notes/v2.0-release-notes.rst
+++ b/source/release-notes/v2.0-release-notes.rst
@@ -50,6 +50,16 @@ Most sites should be able to use ``user_map_match`` instead.  You can still use
 See the :ref:`documentation on user_map_match <ood-portal-generator-user-map-match>`
 for more information on it.
 
+SCL Ruby no longer available to apache
+**************************************
+
+Related to the ood_auth_map.regex change above, apache no longer relies on the SCL version
+of Ruby.  This means that ruby 2.7 is unavailable to apache and consequently any ``user_map_cmd``
+you employ.
+
+Should you need ruby 2.7 in any commands or scripts that apache calls, the best mitigation is
+to employ a wrapper script that can load rh-ruby27.
+
 Ruby and bundler updates
 *************************
 

--- a/source/release-notes/v2.0-release-notes.rst
+++ b/source/release-notes/v2.0-release-notes.rst
@@ -54,10 +54,10 @@ SCL Ruby no longer available to apache
 **************************************
 
 Related to the ood_auth_map.regex change above, apache no longer relies on the SCL version
-of Ruby.  This means that ruby 2.7 is unavailable to apache and consequently any ``user_map_cmd``
+of Ruby.  This means that Fuby 2.7 is unavailable to apache and consequently any ``user_map_cmd``
 you employ.
 
-Should you need ruby 2.7 in any commands or scripts that apache calls, the best mitigation is
+Should you need Ruby 2.7 in any commands or scripts that apache calls, the best mitigation is
 to employ a wrapper script that can load rh-ruby27.
 
 Ruby and bundler updates


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/scl-enables/

2.0 RNs on removing SCL Ruby from apache.

Fixes #510
