### PR TITLE
Fixed widget template path in custom layouts section

### DIFF
--- a/source/customization.rst
+++ b/source/customization.rst
@@ -613,7 +613,7 @@ Custom layouts in the dashboard
 -------------------------------
 
 Administrators can now customize what widgets appear on the dashboard and how they're
-layed out on the page.
+layed out on the page. ``RAILS_ENV`` must be set to production or ``ENV["OOD_LOAD_EXTERNAL_CONFIG”]`` must be enabled.
 
 In it's simplest form this feature allows for a rearrangement of existing widgets. As
 of 2.0 the existing widgets are:
@@ -624,8 +624,8 @@ of 2.0 the existing widgets are:
 - ``xdmod_widget_jobs`` - the XDMoD widget for job information
 
 This feature also allows for administrators to *add* custom widgets.
-Simply drop new files into ``/etc/ood/config/dashboard/views/widgets`` and reference them
-in the configuration.  These partial files can be any format Rails recognizes, notably ``.html`` or
+Simply drop new files into ``/etc/ood/config/apps/dashboard/views/widgets`` or ``ENV["OOD_APP_CONFIG_ROOT”]/views/widgets``
+and reference them in the configuration.  These partial files can be any format Rails recognizes, notably ``.html`` or
 ``.html.erb`` extensions.
 
 Also if you use subdirectories under widgets, they can be referenced by relative paths. For example

--- a/source/customization.rst
+++ b/source/customization.rst
@@ -613,7 +613,7 @@ Custom layouts in the dashboard
 -------------------------------
 
 Administrators can now customize what widgets appear on the dashboard and how they're
-layed out on the page. ``RAILS_ENV`` must be set to production or ``ENV["OOD_LOAD_EXTERNAL_CONFIG”]`` must be enabled.
+layed out on the page.
 
 In it's simplest form this feature allows for a rearrangement of existing widgets. As
 of 2.0 the existing widgets are:
@@ -624,8 +624,8 @@ of 2.0 the existing widgets are:
 - ``xdmod_widget_jobs`` - the XDMoD widget for job information
 
 This feature also allows for administrators to *add* custom widgets.
-Simply drop new files into ``/etc/ood/config/apps/dashboard/views/widgets`` or ``ENV["OOD_APP_CONFIG_ROOT”]/views/widgets``
-and reference them in the configuration.  These partial files can be any format Rails recognizes, notably ``.html`` or
+Simply drop new files into ``/etc/ood/config/apps/dashboard/views/widgets`` and reference them
+in the configuration. These partial files can be any format Rails recognizes, notably ``.html`` or
 ``.html.erb`` extensions.
 
 Also if you use subdirectories under widgets, they can be referenced by relative paths. For example


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

Branch
https://github.com/adaybujeda/ood-documentation/tree/custom_widgets_template_path

Page that modifies:
https://osc.github.io/ood-documentation/release-2.0/customization.html#custom-layouts-in-the-dashboard

Fixes to the template location for custom widgets.
As well as some configuration settings needed for the external location to work.

