### PR TITLE
use latest instead of master as default

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
   <meta charset="UTF-8">
   <title>OOD Documentation</title>
 
-  <meta http-equiv="refresh" content="0;URL='master/'" />
+  <meta http-equiv="refresh" content="0;URL='latest/'" />
 </head>
 
 <body>
   If your browser doesn't automatically redirect you to the documentation page,
-  then please access the  <a href="master/">Documentation</a> directly.
+  then please access the  <a href="latest/">Documentation</a> directly.
 </body>
 </html>


### PR DESCRIPTION
The root of our GH pages uses `master` which we don't update and in fact need to get rid of. Instead we should be using latest.

This will change the behaviour when you land here:
https://osc.github.io/ood-documentation/

And you _should_ be redirected here:
https://osc.github.io/ood-documentation/latest