### PR TITLE
Fix mellon metadata generate command

### DIFF
--- a/source/authentication/adfs-with-auth-mellon.rst
+++ b/source/authentication/adfs-with-auth-mellon.rst
@@ -40,7 +40,7 @@ Note that this configuration assumes that SAML has been configured such that the
    .. code-block:: shell
 
       export mellon_endpoint="https://$(hostname)/mellon"
-      /usr/libexec/mod_auth_mellon/mellon_create_metadata.sh "${mellon_endpoint}" "${mellon_endpoint}/metadata"
+      /usr/libexec/mod_auth_mellon/mellon_create_metadata.sh "${mellon_endpoint}/metadata" "${mellon_endpoint}"
       mv *.cert ./mellon.cert
       mv *.key ./mellon.key
       mv *.xml ./mellon_metadata.xml


### PR DESCRIPTION

https://osc.github.io/ood-documentation-test/develop/authentication/adfs-with-auth-mellon.html

ARG1 and ARG2 are wrongly mentioned in docs

Relevant discussion in https://discourse.osc.edu/t/ood-1-8-and-saml2-and-adfs-authentication/1137