### PR TITLE
add docs for the pun_pre_hook

### DIFF
--- a/source/installation/resource-manager/kubernetes.rst
+++ b/source/installation/resource-manager/kubernetes.rst
@@ -114,6 +114,7 @@ You'll need to employ :ref:`PUN pre hooks <ood-portal-generator-pun-pre-hook>`
 to bootstrap your users to this cluster. You'll also have to modify ``/etc/ood/config/hooks.env``
 
 .. code-block:: text
+
   # /etc/ood/config/hook.env
 
   # required if you changed the items in the cluster.d file

--- a/source/installation/resource-manager/kubernetes.rst
+++ b/source/installation/resource-manager/kubernetes.rst
@@ -111,7 +111,12 @@ to the ``oakley`` namespace.  Refer to the `open ondemand kubernetes resources`_
 for details on the roles and privileges created.
 
 You'll need to employ :ref:`PUN pre hooks <ood-portal-generator-pun-pre-hook>`
-to bootstrap your users to this cluster. You'll also have to modify ``/etc/ood/config/hooks.env``
+to bootstrap your users to this cluster.
+
+You'll also have to modify ``/etc/ood/config/hooks.env`` because `open ondemand provided hooks`_
+require a ``HOOKENV`` environment variable.
+
+Here's what you'll have to edit in the ``hook.env.example`` file we ship.
 
 .. code-block:: text
 
@@ -136,6 +141,43 @@ to bootstrap your users to this cluster. You'll also have to modify ``/etc/ood/c
   # enable if are enforcing walltimes through the job pod reaper
   # see 'Enforcing walltimes' below.
   USE_JOB_POD_REAPER=false
+
+You can refer to `osc's prehook`_ but we'll also provide this example.
+As you can see in this pre hook, the username is passed in to the script
+which then defines the ``HOOKENV`` and calls two `open ondemand provided hooks`_.
+
+``k8s-bootstrap-ondemand.sh`` boostraps the user in the kubernetes cluster as described
+above.
+
+Since we use OIDC at OSC we use ``set-k8s-creds.sh`` to add or update the user in their
+``~/.kube/config`` with the relevant OIDC credentials.
+
+.. code-block:: shell
+
+  #!/bin/bash
+
+  for arg in "$@"
+  do
+    case $arg in
+      --user)
+      ONDEMAND_USERNAME=$2
+      shift
+      shift
+      ;;
+  esac
+  done
+
+  if [ "x${ONDEMAND_USERNAME}" = "x" ]; then
+    echo "Must specify username"
+    exit 1
+  fi
+
+  HOOKSDIR="/opt/ood/hooks"
+  HOOKENV="/etc/ood/config/hook.env"
+
+  /bin/bash "$HOOKSDIR/k8s-bootstrap/k8s-bootstrap-ondemand.sh" "$ONDEMAND_USERNAME" "$HOOKENV"
+  /bin/bash "$HOOKSDIR/k8s-bootstrap/set-k8s-creds.sh" "$ONDEMAND_USERNAME" "$HOOKENV"
+
 
 Authentication
 **************
@@ -238,3 +280,4 @@ OIDC Audicence
 .. _kubernetes security context: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context
 .. _open ondemand provided hooks: https://github.com/OSC/ondemand/tree/master/hooks
 .. _open ondemand kubernetes resources: https://github.com/OSC/ondemand/blob/master/hooks/k8s-bootstrap/ondemand.yaml
+.. _osc's prehook: https://github.com/OSC/osc-ood-config/blob/master/hooks/pre-hook.sh

--- a/source/installation/resource-manager/kubernetes.rst
+++ b/source/installation/resource-manager/kubernetes.rst
@@ -110,6 +110,32 @@ The RoleBindings give user, ``oakley`` in this case, sufficient privileges
 to the ``oakley`` namespace.  Refer to the `open ondemand kubernetes resources`_
 for details on the roles and privileges created.
 
+You'll need to employ :ref:`PUN pre hooks <ood-portal-generator-pun-pre-hook>`
+to bootstrap your users to this cluster. You'll also have to modify ``/etc/ood/config/hooks.env``
+
+.. code-block:: text
+  # /etc/ood/config/hook.env
+
+  # required if you changed the items in the cluster.d file
+  K8S_USERNAME_PREFIX=""
+  NAMESPACE_PREFIX=""
+
+  # required
+  NETWORK_POLICY_ALLOW_CIDR="127.0.0.1/32"
+
+  # required if you're using OIDC
+  IDP_ISSUER_URL="https://idp.example.com/auth/realms/main/protocol/openid-connect/token"
+  CLIENT_ID="changeme"
+  CLIENT_SECRET="changeme"
+
+  # required if you're using a secret registry
+  IMAGE_PULL_SECRET=""
+  REGISTRY_DOCKER_CONFIG_JSON="/some/path/to/docker/config.json"
+
+  # enable if are enforcing walltimes through the job pod reaper
+  # see 'Enforcing walltimes' below.
+  USE_JOB_POD_REAPER=false
+
 Authentication
 **************
 

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -53,6 +53,25 @@ Configure General Options
 
           servername: "www.example.com"
 
+.. describe:: proxy_server (String, null)
+
+  The proxy server, if one exists. Used when you have a proxy
+  in front of the Open OnDemand server(s).
+
+  Default
+    No proxy server
+
+    .. code-block:: yaml
+
+      proxy_server: null
+
+  Example
+    Access website through the proxy name ``www.example-proxy.com``
+
+    .. code-block:: yaml
+
+      proxy_server: "www.example-proxy.com"
+
 .. describe:: port (Integer, null)
 
      the port used to access the Open OnDemand portal (if different than ``80``
@@ -112,6 +131,60 @@ Configure General Options
        .. code-block:: yaml
 
           logroot: "/path/to/my/logs"
+
+.. describe:: errorlog (String, 'error.log')
+
+  The Error log filename
+
+  Default
+    "error.log"
+
+    .. code-block:: yaml
+
+      errorlog: "error.log"
+
+  Example
+    "my.site.error.log"
+
+    .. code-block:: yaml
+
+      errorlog: "my.site.error.log"
+
+.. describe:: accesslog (String, 'access.log')
+
+  The Access log filename
+
+  Default
+    "access.log"
+
+    .. code-block:: yaml
+
+      accesslog: "access.log"
+
+  Example
+    "my.site.access.log"
+
+    .. code-block:: yaml
+
+      accesslog: "my.site.access.log"
+
+.. describe:: logformat (String, apache conbined format)
+
+  The log format.
+
+  Default
+    apache combined format
+
+    .. code-block:: yaml
+
+      logformat: null
+
+  Example
+    Change the error and access log format.
+
+    .. code-block:: yaml
+
+      logformat: '"%v %h \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %{SSL_PROTOCOL}x %T"'
 
 .. describe:: use_rewrites (Boolean)
 
@@ -297,7 +370,6 @@ Configure General Options
    .. code-block:: yaml
 
       user_map_match: '^([^@]+)@example.edu$'
-
 
 .. _ood-portal-generator-user-env:
 .. describe:: user_env (String, null)
@@ -697,6 +769,65 @@ properties are ``null`` then PUN access will be disabled.
        .. code-block:: yaml
 
           pun_max_retries: 25
+
+.. _ood-portal-generator-pun-pre-hook:
+
+PUN Pre Hook command is functionality to initialize things as root before
+the PUN starts up.
+
+Authentication information like OIDC tokens are not passed to OnDemand apps like
+the dashboard.  This feature is useful when you need to use things like OIDC tokens
+in some initialization process before the PUN starts.  For example, you can
+configure your ~/.kube/config with OIDC information with this feature.
+
+There is currently only one thing passed into this command and that is the
+username. It's passed as a named argument like so: ``--user USERNAME``.
+
+You may pass in environment variables from apache to this command, though they are
+prefixed with ``OOD_``. For example if you configure this to pass ``OIDC_ACCESS_TOKEN``
+to the pre hook command, you can read the variable as ``OOD_OIDC_ACCESS_TOKEN``.
+
+Additionally you may add entries to ``/etc/ood/config/hook.env`` and source this
+file for additional environment variables. For example environment specific information
+for your test and production environments.
+
+.. describe:: pun_pre_hook_root_cmd (String, null)
+
+  Run a hook command as root before the the PUN starts up.
+
+  Default
+    No pun pre hook.
+
+    .. code-block:: yaml
+
+      pun_pre_hook_root_cmd: null
+
+  Example
+    Run a pre hook called "my_site_hook.sh".
+
+    .. code-block:: yaml
+
+      pun_pre_hook_root_cmd: "/path/to/my_site_hook.sh"
+
+.. describe:: pun_pre_hook_exports (String, null)
+
+  A comma seperated list of environment variables to export to the
+  pun_pre_hook_root_cmd.
+
+  Default
+    Don't pass any environment variables.
+
+    .. code-block:: yaml
+
+      pun_pre_hook_exports: null
+
+  Example
+    Export OIDC_ACCESS_TOKEN and OIDC_CLAIM_EMAIL environment variables
+    to the pun_pre_hook_root_cmd.
+
+    .. code-block:: yaml
+
+      pun_pre_hook_exports: "OIDC_ACCESS_TOKEN,OIDC_CLAIM_EMAIL"
 
 Configure OpenID Connect
 ------------------------


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/add-pun-pre-hook

Fixes #439.  I'm going to create a new ticket to move the docs about the `hook.env` out of the k8s cluster config doc.
