### PR TITLE
Improvements to OS support documentation

### DIFF
--- a/source/app-development/interactive/setup/enable-reverse-proxy.rst
+++ b/source/app-development/interactive/setup/enable-reverse-proxy.rst
@@ -155,7 +155,7 @@ Steps to Enable in Apache
 
         sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
 
-   RHEL/Rocky Linux 8:
+   RHEL/Rocky 8:
      .. code-block:: sh
 
         sudo systemctl try-restart httpd.service htcacheclean.service

--- a/source/app-development/interactive/setup/enable-reverse-proxy.rst
+++ b/source/app-development/interactive/setup/enable-reverse-proxy.rst
@@ -150,10 +150,20 @@ Steps to Enable in Apache
 
 #. Restart the Apache server to have the changes take effect:
 
-   CentOS/RHEL 7:
+   RHEL/CentOS 7:
      .. code-block:: sh
 
         sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
+
+   RHEL/Rocky Linux 8:
+     .. code-block:: sh
+
+        sudo systemctl try-restart httpd.service htcacheclean.service
+
+   Ubuntu:
+     .. code-block:: sh
+
+        sudo systemctl try-restart apache2.service
 
 Verify it Works
 ---------------

--- a/source/authentication/oidc.rst
+++ b/source/authentication/oidc.rst
@@ -12,7 +12,7 @@ The following prerequisites need to be satisfied:
 
 .. note::
 
-   OnDemand repos provide the ``https24-mod_auth_openidc`` RPM for RHEL 7 and CentOS 7 as it must be built against SCL Apache. The OnDemand repos also have the ``mod_auth_openidc`` RPM for RHEL 8 and Rocky Linux 8 that are newer than what the OS provides to make use of some newer features.
+   OnDemand repos provide the ``https24-mod_auth_openidc`` RPM for RHEL 7 and CentOS 7 as it must be built against SCL Apache. The OnDemand repos also have the ``mod_auth_openidc`` RPM for RHEL 8 and Rocky 8 that are newer than what the OS provides to make use of some newer features.
 
 The following is an example :program:`ood-portal-generator` configuration file:
 

--- a/source/authentication/oidc.rst
+++ b/source/authentication/oidc.rst
@@ -12,7 +12,7 @@ The following prerequisites need to be satisfied:
 
 .. note::
 
-   OnDemand repos provide the ``https24-mod_auth_openidc`` RPM for RHEL 7 and CentOS 7 as it must be built against SCL Apache
+   OnDemand repos provide the ``https24-mod_auth_openidc`` RPM for RHEL 7 and CentOS 7 as it must be built against SCL Apache. The OnDemand repos also have the ``mod_auth_openidc`` RPM for RHEL 8 and Rocky Linux 8 that are newer than what the OS provides to make use of some newer features.
 
 The following is an example :program:`ood-portal-generator` configuration file:
 

--- a/source/authentication/pam.rst
+++ b/source/authentication/pam.rst
@@ -25,7 +25,7 @@ PAM can be used to authenticate users to OnDemand, for example if users only exi
 
       sudo echo "LoadModule authnz_pam_module modules/mod_authnz_pam.so" > /opt/rh/httpd24/root/etc/httpd/conf.modules.d/55-authnz_pam.conf
 
-   RHEL/CentOS 8:
+   RHEL/Rocky Linux 8:
 
    .. code-block:: sh
 

--- a/source/authentication/pam.rst
+++ b/source/authentication/pam.rst
@@ -25,7 +25,7 @@ PAM can be used to authenticate users to OnDemand, for example if users only exi
 
       sudo echo "LoadModule authnz_pam_module modules/mod_authnz_pam.so" > /opt/rh/httpd24/root/etc/httpd/conf.modules.d/55-authnz_pam.conf
 
-   RHEL/Rocky Linux 8:
+   RHEL/Rocky 8:
 
    .. code-block:: sh
 

--- a/source/installation/add-ssl.rst
+++ b/source/installation/add-ssl.rst
@@ -61,10 +61,20 @@ Intermediate certificate
 
 #. Restart the Apache server to have the changes take effect:
 
-   CentOS/RHEL 7:
+   RHEL/CentOS 7:
      .. code-block:: sh
 
         sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
+
+   RHEL/Rocky Linux 8:
+     .. code-block:: sh
+
+        sudo systemctl try-restart httpd.service htcacheclean.service
+
+   Ubuntu:
+     .. code-block:: sh
+
+        sudo systemctl try-restart apache2.service
 
 Now when you browse to your OnDemand portal at::
 

--- a/source/installation/add-ssl.rst
+++ b/source/installation/add-ssl.rst
@@ -66,7 +66,7 @@ Intermediate certificate
 
         sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
 
-   RHEL/Rocky Linux 8:
+   RHEL/Rocky 8:
      .. code-block:: sh
 
         sudo systemctl try-restart httpd.service htcacheclean.service

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -1,7 +1,7 @@
 .. _install-software:
 
-Install Software From RPM
-=========================
+Install Software From Packages
+==============================
 
 We will use `Software Collections`_ to satisfy majority of the following
 software requirements:
@@ -36,20 +36,21 @@ software requirements:
       attach a subscription providing access to RHSCL to be able to use this
       repository.
 
-#. Enable dnf modules and repositories for dependencies **on CentOS/RHEL 8 only**:
+#. Enable dnf modules and repositories for dependencies **on RHEL/Rocky Linux 8 only**:
 
     .. code-block:: sh
 
+       dnf install epel-release
        dnf module enable ruby:2.7
-       dnf module enable nodejs:12
+       dnf module enable nodejs:14
 
-    **CentOS 8 only**
+   **Rocky Linux 8 only**
 
     .. code-block:: sh
 
        sudo dnf config-manager --set-enabled powertools
 
-    **RedHat 8 only**
+   **RedHat 8 only**
 
     .. code-block:: sh
 
@@ -57,15 +58,34 @@ software requirements:
 
 #. Add Open OnDemand's repository hosted by the `Ohio Supercomputer Center`_:
 
-     .. code-block:: sh
+   **RedHat/CentOS/Rocky Linux only**
 
-        sudo yum install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-1.noarch.rpm
+    .. code-block:: sh
+
+       sudo yum install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-1.noarch.rpm
+
+   **Ubuntu only**
+
+    .. code-block:: sh
+
+       sudo apt install apt-transport-https ca-certificates
+       wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.0_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.0_all.deb
+       sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.0_all.deb
+       sudo apt update
 
 #. Install OnDemand and all of its dependencies:
 
-   .. code-block:: sh
+   **RedHat/CentOS/Rocky Linux only**
 
-      sudo yum install ondemand
+    .. code-block:: sh
+
+       sudo yum install ondemand
+
+   **Ubuntu only**
+
+    .. code-block:: sh
+
+       sudo apt install ondemand
 
 #. (Optional) Install :ref:`authentication-dex` package
 
@@ -74,15 +94,25 @@ software requirements:
       If authenticating against LDAP or wishing to evaluate OnDemand using `ood` user, you must install `ondemand-dex`.
       See :ref:`add-ldap` for details on configuration of LDAP.
 
-   .. code-block:: sh
+   **RedHat/CentOS/Rocky Linux only**
 
-      sudo yum install ondemand-dex
+    .. code-block:: sh
+
+       sudo yum install ondemand-dex
+
+   **Ubuntu only**
+
+    .. code-block:: sh
+
+       sudo apt install ondemand-dex
 
 #. (Optional) Install OnDemand SELinux support if you have SELinux enabled. For details see :ref:`ood_selinux`
 
-   .. code-block:: sh
+   **RedHat/CentOS/Rocky Linux only**
 
-      sudo yum install ondemand-selinux
+    .. code-block:: sh
+
+       sudo yum install ondemand-selinux
 
 .. note::
 

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -36,7 +36,7 @@ software requirements:
       attach a subscription providing access to RHSCL to be able to use this
       repository.
 
-#. Enable dnf modules and repositories for dependencies **on RHEL/Rocky Linux 8 only**:
+#. Enable dnf modules and repositories for dependencies **on RHEL/Rocky 8 only**:
 
     .. code-block:: sh
 
@@ -44,7 +44,7 @@ software requirements:
        dnf module enable ruby:2.7
        dnf module enable nodejs:14
 
-   **Rocky Linux 8 only**
+   **Rocky 8 only**
 
     .. code-block:: sh
 
@@ -58,7 +58,7 @@ software requirements:
 
 #. Add Open OnDemand's repository hosted by the `Ohio Supercomputer Center`_:
 
-   **RedHat/CentOS/Rocky Linux only**
+   **RedHat/CentOS/Rocky only**
 
     .. code-block:: sh
 
@@ -75,7 +75,7 @@ software requirements:
 
 #. Install OnDemand and all of its dependencies:
 
-   **RedHat/CentOS/Rocky Linux only**
+   **RedHat/CentOS/Rocky only**
 
     .. code-block:: sh
 
@@ -94,7 +94,7 @@ software requirements:
       If authenticating against LDAP or wishing to evaluate OnDemand using `ood` user, you must install `ondemand-dex`.
       See :ref:`add-ldap` for details on configuration of LDAP.
 
-   **RedHat/CentOS/Rocky Linux only**
+   **RedHat/CentOS/Rocky only**
 
     .. code-block:: sh
 
@@ -108,7 +108,7 @@ software requirements:
 
 #. (Optional) Install OnDemand SELinux support if you have SELinux enabled. For details see :ref:`ood_selinux`
 
-   **RedHat/CentOS/Rocky Linux only**
+   **RedHat/CentOS/Rocky only**
 
     .. code-block:: sh
 

--- a/source/installation/start-apache.rst
+++ b/source/installation/start-apache.rst
@@ -9,17 +9,23 @@ Please see section :ref:`add-ldap` for a more advanced and recommended authentic
 
 #. Start the Apache HTTP Server:
 
-   CentOS/RHEL 7
+   RHEL/CentOS 7
      .. code-block:: sh
 
         sudo systemctl start httpd24-httpd
         sudo systemctl enable httpd24-httpd
 
-   CentOS/RHEL 8
+   RHEL/Rocky Linux 8
      .. code-block:: sh
 
         sudo systemctl start httpd
         sudo systemctl enable httpd
+
+   Ubuntu
+     .. code-block:: sh
+
+        sudo systemctl start apache2
+        sudo systemctl enable apache2
 
    .. warning::
 
@@ -31,11 +37,10 @@ Please see section :ref:`add-ldap` for a more advanced and recommended authentic
 
    If using the default OnDemand authentication mechanism, you must start the ``ondemand-dex`` service.
 
-   CentOS/RHEL 7 & 8
-     .. code-block:: sh
+   .. code-block:: sh
 
-        sudo systemctl start ondemand-dex
-        sudo systemctl enable ondemand-dex
+      sudo systemctl start ondemand-dex
+      sudo systemctl enable ondemand-dex
 
 #. (Optional) Configure default user
 

--- a/source/installation/start-apache.rst
+++ b/source/installation/start-apache.rst
@@ -15,7 +15,7 @@ Please see section :ref:`add-ldap` for a more advanced and recommended authentic
         sudo systemctl start httpd24-httpd
         sudo systemctl enable httpd24-httpd
 
-   RHEL/Rocky Linux 8
+   RHEL/Rocky 8
      .. code-block:: sh
 
         sudo systemctl start httpd

--- a/source/monitoring/prometheus.rst
+++ b/source/monitoring/prometheus.rst
@@ -25,7 +25,7 @@ Dependencies:
 Install via RPM
 --------------------------
 
-For RHEL/CentOS 7 and RHEL/Rocky Linux 8 systems the `ondemand_exporter`_ can be installed via RPM.
+For RHEL/CentOS 7 and RHEL/Rocky 8 systems the `ondemand_exporter`_ can be installed via RPM.
 
 .. code-block:: sh
 
@@ -34,7 +34,7 @@ For RHEL/CentOS 7 and RHEL/Rocky Linux 8 systems the `ondemand_exporter`_ can be
 The RPM will install the following files that should work out of the box:
 
 - **RHEL/CentOS 7 only**: /opt/rh/httpd24/root/etc/httpd/conf.d/ondemand_exporter.conf
-- **RHEL/Rocky Linux 8 only**: /etc/httpd/conf.d/ondemand_exporter.conf
+- **RHEL/Rocky 8 only**: /etc/httpd/conf.d/ondemand_exporter.conf
 - /etc/sudoers.d/ondemand_exporter
 
 Ensure that the new Apache configuration is loaded by restarting Apache
@@ -45,7 +45,7 @@ RHEL/CentOS 7
 
     sudo systemctl restart httpd24-httpd
 
-RHEL/Rocky Linux 8
+RHEL/Rocky 8
 
  .. code-block:: sh
 
@@ -85,7 +85,7 @@ RHEL/CentOS 7
      sudo install -o root -g root -m 0440 /tmp/${ARCHIVE}/files/apache.conf /opt/rh/httpd24/root/etc/httpd/conf.d/ondemand_exporter.conf
      sudo systemctl restart httpd24-httpd
 
-RHEL/Rocky Linux 8
+RHEL/Rocky 8
 
   .. code-block:: sh
 

--- a/source/monitoring/prometheus.rst
+++ b/source/monitoring/prometheus.rst
@@ -25,7 +25,7 @@ Dependencies:
 Install via RPM
 --------------------------
 
-For RHEL/CentOS 7 and 8 systems the `ondemand_exporter`_ can be installed via RPM.
+For RHEL/CentOS 7 and RHEL/Rocky Linux 8 systems the `ondemand_exporter`_ can be installed via RPM.
 
 .. code-block:: sh
 
@@ -34,7 +34,7 @@ For RHEL/CentOS 7 and 8 systems the `ondemand_exporter`_ can be installed via RP
 The RPM will install the following files that should work out of the box:
 
 - **RHEL/CentOS 7 only**: /opt/rh/httpd24/root/etc/httpd/conf.d/ondemand_exporter.conf
-- **RHEL/CentOS 8 only**: /etc/httpd/conf.d/ondemand_exporter.conf
+- **RHEL/Rocky Linux 8 only**: /etc/httpd/conf.d/ondemand_exporter.conf
 - /etc/sudoers.d/ondemand_exporter
 
 Ensure that the new Apache configuration is loaded by restarting Apache
@@ -45,7 +45,7 @@ RHEL/CentOS 7
 
     sudo systemctl restart httpd24-httpd
 
-RHEL/CentOS 8
+RHEL/Rocky Linux 8
 
  .. code-block:: sh
 
@@ -85,7 +85,7 @@ RHEL/CentOS 7
      sudo install -o root -g root -m 0440 /tmp/${ARCHIVE}/files/apache.conf /opt/rh/httpd24/root/etc/httpd/conf.d/ondemand_exporter.conf
      sudo systemctl restart httpd24-httpd
 
-RHEL/CentOS 8
+RHEL/Rocky Linux 8
 
   .. code-block:: sh
 

--- a/source/reference/commands/ood-portal-generator.rst
+++ b/source/reference/commands/ood-portal-generator.rst
@@ -98,7 +98,7 @@ Options
       The systemd file for Apache will run the update_ood_portal script with defaults
       and will not use a different file, rendering this option obsolete unless you also
       modify systemd config (``/etc/systemd/system/httpd24-httpd.service.d/ood.conf`` in
-      CentOS 7, ``/etc/systemd/system/httpd.service.d/ood.conf`` in CentOS 8).
+      RHEL 7, ``/etc/systemd/system/httpd.service.d/ood.conf`` in RHEL 8).
 
 .. option:: -t <template>, --template <template>
 
@@ -118,6 +118,6 @@ Options
       The systemd file for Apache will run the update_ood_portal script with defaults
       and will not use a different file, rendering this option obsolete unless you also
       modify systemd config (``/etc/systemd/system/httpd24-httpd.service.d/ood.conf`` in
-      CentOS 7, ``/etc/systemd/system/httpd.service.d/ood.conf`` in CentOS 8).
+      RHEL 7, ``/etc/systemd/system/httpd.service.d/ood.conf`` in RHEL 8).
 
 .. _apache configuration: https://httpd.apache.org/docs/2.4/configuring.html

--- a/source/release-notes/v2.1-release-notes.rst
+++ b/source/release-notes/v2.1-release-notes.rst
@@ -54,7 +54,7 @@ Upgrade directions
 
 #. Enable dependency repos
 
-   **RHEL/Rocky Linux 8 only**
+   **RHEL/Rocky 8 only**
 
    .. code-block:: sh
 
@@ -80,7 +80,7 @@ Upgrade directions
 
       sudo /opt/ood/ood-portal-generator/sbin/update_ood_portal
 
-   **RHEL/Rocky Linux 8 only**
+   **RHEL/Rocky 8 only**
 
    .. code-block:: sh
 

--- a/source/release-notes/v2.1-release-notes.rst
+++ b/source/release-notes/v2.1-release-notes.rst
@@ -11,6 +11,7 @@ v2.1 Release Notes
 Highlights in 2.1:
 
 - `Dynamic Javascript in BatchConnect Forms`_
+- `Ubuntu 20.04 packages`_
 - `Dependency updates`_
 
 Upgrading from v2.0
@@ -53,30 +54,12 @@ Upgrade directions
 
 #. Enable dependency repos
 
-   **CentOS/RHEL 8 only**
+   **RHEL/Rocky Linux 8 only**
 
    .. code-block:: sh
 
       sudo dnf module reset nodejs
       sudo dnf module enable nodejs:14
-
-   **RedHat 8 only**
-
-   .. code-block:: sh
-
-      sudo subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-
-   **CentOS 8 only**
-
-   .. code-block:: sh
-
-      sudo dnf config-manager --set-enabled powertools
-
-   **CentOS/RHEL 7 only**
-
-   .. code-block:: sh
-
-      sudo yum install epel-release
 
 #. Update OnDemand
 
@@ -97,13 +80,13 @@ Upgrade directions
 
       sudo /opt/ood/ood-portal-generator/sbin/update_ood_portal
 
-   **CentOS/RHEL 8 only**
+   **RHEL/Rocky Linux 8 only**
 
    .. code-block:: sh
 
       sudo systemctl try-restart httpd
 
-   **CentOS/RHEL 7 only**
+   **RHEL/CentOS 7 only**
 
    .. code-block:: sh
 
@@ -127,7 +110,7 @@ Upgrade directions
 
       See `Dependency updates`_ warning before uninstalling old Ruby versions.
 
-   **CentOS/RHEL 7 only**
+   **RHEL/CentOS 7 only**
 
    .. code-block:: sh
 
@@ -141,7 +124,10 @@ Dynamic Javascript in BatchConnect Forms
 ........................................
 
 
+Ubuntu 20.04 packages
+.....................
 
+See :ref:`Install Software <install-software>` for instructions on how to install OnDemand using the new Ubuntu 20.04 packages.
 
 Dependency updates
 ..................


### PR DESCRIPTION
Document Ubuntu install and update 2.1 release notes, fixes #572
Replace CentOS 8 with Rocky Linux 8 where appropriate, fixes #570

**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/ubuntu-rocky/

**Add your description here**
