### PR TITLE
Adding web and compute node definitions with examples.

### DIFF
--- a/source/architecture.rst
+++ b/source/architecture.rst
@@ -10,13 +10,29 @@ Below are some diagrams of OnDemand's architecture:
    model for software diagrams, are more technically detailed and are built using draw.io
 #. Request flow diagram is a sequence diagram built using plantuml
 
+Useful Terms
+------------
+
+#. **Web-node**: Refers to the Apache web server which runs as the apache user.
+
+   * Handles authentication and tracking the user session.
+   * Tracks the various `fs` paths that it will associate with the compute nodes which it submit requests to from form data.
+   * Proxies requests to the compute nodes.
+
+#. **Compute-node**: Interactive apps and resource managers that run as the authenticated user. These nodes are proxied requests *from* the *web-node* and include things like: 
+
+   * RStudio (http server)
+   * Jupyter (http server)
+   * Ansys (no http server included, needs noVNC)
+   * Resource managers like SLURM, Torque, etc
+
 Overview
 --------
 
-
 .. figure:: /architecture/ood_overview.png
 
-#. Apache is the server front end, running as the Apache user, and accepting all requests from users and serves four primary functions
+#. Apache is the server front end which will be referred to as the **web-node** in these docs, 
+   running as the Apache user, and accepting all requests from users and serves four primary functions
 
    #. Authenticates user
    #. Starts Per-User NGINX processes (PUNs)

--- a/source/architecture.rst
+++ b/source/architecture.rst
@@ -16,7 +16,7 @@ Useful Terms
 #. **Web-node**: Refers to the Apache web server which runs as the apache user.
 
    * Handles authentication and tracking the user session.
-   * Tracks the various `fs` paths that it will associate with the compute nodes which it submit requests to from form data.
+   * Tracks the various `fs` paths that it will associate with the compute nodes which it submits requests to using form data.
    * Proxies requests to the compute nodes.
 
 #. **Compute-node**: Interactive apps and resource managers that run as the authenticated user. These nodes are proxied requests *from* the *web-node* and include things like: 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/compute-web-node-defns/

altered `architecture` page.

**Add your description here**
Adding explicit definitions for the web-node and compute-node in the overview. Fixes #595 