### PR TITLE
use dockerhub when u can and warn folks about our registry

### DIFF
--- a/source/app-development/tutorials-interactive-apps/k8s-jupyter.rst
+++ b/source/app-development/tutorials-interactive-apps/k8s-jupyter.rst
@@ -204,7 +204,7 @@ submit yml in full
     # here's the bulk of setting up the container. You'll likely need to specify all of these.
     container:
       name: "jupyter"
-      image: "docker.io/jupyter/scipy-notebook:python-3.9.2"
+      image: "docker.io/jupyter/scipy-notebook:python-3.9.7"
       command: "/usr/local/bin/start.sh /opt/conda/bin/jupyter notebook --config=/ood/ondemand_config.py"
       working_dir: "<%= Etc.getpwnam(ENV['USER']).dir %>"
       restart_policy: 'OnFailure'

--- a/source/app-development/tutorials-interactive-apps/k8s-jupyter.rst
+++ b/source/app-development/tutorials-interactive-apps/k8s-jupyter.rst
@@ -35,7 +35,7 @@ Next you can specify additional environment variables in ``env``.
 
   container:
     name: "jupyter"
-    image: "docker-registry.osc.edu/ondemand/scipy-notebook:python-3.9.2"
+    image: "docker.io/jupyter/scipy-notebook:python-3.9.7"
     command: "/usr/local/bin/start.sh /opt/conda/bin/jupyter notebook --config=/ood/ondemand_config.py"
     working_dir: "<%= Etc.getpwnam(ENV['USER']).dir %>"
     restart_policy: 'OnFailure'
@@ -204,7 +204,7 @@ submit yml in full
     # here's the bulk of setting up the container. You'll likely need to specify all of these.
     container:
       name: "jupyter"
-      image: "docker-registry.osc.edu/ondemand/scipy-notebook:python-3.9.2"
+      image: "docker.io/jupyter/scipy-notebook:python-3.9.2"
       command: "/usr/local/bin/start.sh /opt/conda/bin/jupyter notebook --config=/ood/ondemand_config.py"
       working_dir: "<%= Etc.getpwnam(ENV['USER']).dir %>"
       restart_policy: 'OnFailure'

--- a/source/app-development/tutorials-interactive-apps/k8s-like-hpc-jupyter.rst
+++ b/source/app-development/tutorials-interactive-apps/k8s-like-hpc-jupyter.rst
@@ -70,6 +70,10 @@ The ``image`` should be the HPC container image and ``command`` will be the job 
 work with both SLURM and Kubernetes.  The ``command`` will be run from the user's home directory and will cover mount
 requirements in :ref:`mount requirements <kubernetes-mount-requirements>`.
 
+.. warning::
+  These examples use images from the Ohio SuperComputer Center's private registry. They will
+  not work at your site as this registry requires authentication.
+
 One important aspect of the ``command`` is that the job script executed is built using the standard ``before.sh``, ``script.sh`` and ``after.sh`` that one would normally use to build the job script for interactive apps running
 on HPC resources.  The way this pod is being setup, the same job script that runs on SLURM would also be used to
 launch the container in Kubernetes.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/dockerhub-k8s/

There's a pitfall here where folks copy this and can't use images off of our registry. So let's use dockerhub where applicable and add a warning for our HPC image.
