### PR TITLE
Fix alternate text cluster selection widget example

### DIFF
--- a/source/app-development/interactive/form.rst
+++ b/source/app-development/interactive/form.rst
@@ -602,8 +602,8 @@ different text than the default.
      cluster:
        widget: "select"
        options:
-         - ["cluster1", "The first cluster"]
-         - ["cluster2", "The second cluster"]
+         - ["The first cluster", "cluster1"]
+         - ["The second cluster", "cluster2"]
 
 The last option is to :ref:`configure the cluster in the submit file <configuring-cluster-in-submit-yml>`.
 When using this option, there's no need to add any cluster configuration to the


### PR DESCRIPTION
The ordering of the cluster name and the alternate text was incorrect in the provided example. It works properly the other way around.

https://osc.github.io/ood-documentation/latest/app-development/interactive/form.html?highlight=cluster#configuring-which-cluster-to-submit-to
