### PR TITLE
mv relase notes to 1 single heading

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -52,6 +52,7 @@ These are institutions who were early adopters or provided HPC resources for dev
 
    architecture
    reference
+   release-notes
    glossary
 
 
@@ -104,21 +105,6 @@ These are institutions who were early adopters or provided HPC resources for dev
 
    app-development/tutorials-passenger-apps
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Release Notes
-
-   release-notes/v2.1-release-notes
-   release-notes/v2.0-release-notes
-   release-notes/v1.8-release-notes
-   release-notes/v1.7-release-notes
-   release-notes/v1.6-release-notes
-   release-notes/v1.5-release-notes
-   release-notes/v1.4-release-notes
-   release-notes/v1.3-release-notes
-   release-notes/v1.2-release-notes
-   release-notes/v1.1-release-notes
-   release-notes/v1.0-release-notes
 
 .. toctree::
    :maxdepth: 2

--- a/source/release-notes.rst
+++ b/source/release-notes.rst
@@ -1,0 +1,19 @@
+.. _release_notes:
+
+Release Notes
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   release-notes/v2.1-release-notes
+   release-notes/v2.0-release-notes
+   release-notes/v1.8-release-notes
+   release-notes/v1.7-release-notes
+   release-notes/v1.6-release-notes
+   release-notes/v1.5-release-notes
+   release-notes/v1.4-release-notes
+   release-notes/v1.3-release-notes
+   release-notes/v1.2-release-notes
+   release-notes/v1.1-release-notes
+   release-notes/v1.0-release-notes


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/mv-rns/

This collapses the left navbar's release notes heading into a subheading.
