### PR TITLE
typo: triple backtick→ double backtick

### DIFF
--- a/source/customization.rst
+++ b/source/customization.rst
@@ -1012,7 +1012,7 @@ The time ranges and values for labels (eg: `var-cluster=`) will be autofilled by
 
 * ``orgId`` is the ``orgId`` query parameter
 * The dashboard ``name`` is the last segment of the URI before query parameters
-* The ``uid``` is the UID portion of URL that is unique to every dashboard
+* The ``uid`` is the UID portion of URL that is unique to every dashboard
 * The ``panelId`` query parameter will be used as the value for either ``cpu`` or ``memory`` depending on the panel you have selected
 * The values for ``labels`` are how OnDemand maps labels in Grafana to values expected in OnDemand. The ``jobid`` key is optional, the others are required.
 * The ``cluster_override`` can override the cluster name used to make requests to Grafana if the Grafana cluster name varies from OnDemand cluster name.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/develop/

just a typo fix.
