### PR TITLE
Update slurm config documentation to reference additional commands if not using SCL

### DIFF
--- a/source/installation/resource-manager/test.rst
+++ b/source/installation/resource-manager/test.rst
@@ -22,7 +22,7 @@ configuration files.
 
 #. We will now list all available tasks that we can run:
 
-   .. rubric:: If you are using SCL, run the following command:
+   .. rubric:: If your O/S is CentOS 7 or RHEL 7, run this command:
 
    .. code-block:: sh
 
@@ -32,7 +32,7 @@ configuration files.
       # rake test:jobs:cluster2  # Test the cluster: cluster2
 
 
-   .. rubric:: If you are NOT using SCL, run the following command:
+   .. rubric:: Otherwise, run this command:
 
    .. code-block:: sh
 
@@ -51,13 +51,13 @@ configuration files.
    ``cluster1``, so you will need to replace it with the name of the cluster
    you configured):
 
-      .. rubric:: If you are using SCL, run the following command:
+      .. rubric:: If your O/S is CentOS 7 or RHEL 7, run this command:
 
       .. code-block:: sh
 
          sudo su $USER -c 'scl enable ondemand -- bin/rake test:jobs:cluster1 RAILS_ENV=production'
 
-      .. rubric:: If you are NOT using SCL, run the following command:
+      .. rubric:: Otherwise, run this command:
 
       .. code-block:: sh
 
@@ -113,13 +113,13 @@ configuration files.
       provide these command line arguments as a string with the environment
       variable ``SUBMIT_ARGS`` as:
 
-      .. rubric:: If you are using SCL, run the following command:
+      .. rubric:: If your O/S is CentOS 7 or RHEL 7, run this command:
 
       .. code-block:: sh
 
          sudo su $USER -c 'scl enable ondemand-- bin/rake test:jobs:cluster1 RAILS_ENV=production SUBMIT_ARGS="-A myaccount"'
          
-      .. rubric:: If you are NOT using SCL, run the following command:
+      .. rubric:: Otherwise, run this command:
 
       .. code-block:: sh
 

--- a/source/installation/resource-manager/test.rst
+++ b/source/installation/resource-manager/test.rst
@@ -22,9 +22,22 @@ configuration files.
 
 #. We will now list all available tasks that we can run:
 
+   .. rubric:: If you are using SCL, run the following command:
+
    .. code-block:: sh
 
       scl enable ondemand -- bin/rake -T test:jobs
+      # rake test:jobs           # Test all clusters
+      # rake test:jobs:cluster1  # Test the cluster: cluster1
+      # rake test:jobs:cluster2  # Test the cluster: cluster2
+
+
+   .. rubric:: If you are NOT using SCL, run the following command:
+
+   .. code-block:: sh
+
+      source /opt/ood/ondemand/enable
+      bin/rake -T test:jobs
       # rake test:jobs           # Test all clusters
       # rake test:jobs:cluster1  # Test the cluster: cluster1
       # rake test:jobs:cluster2  # Test the cluster: cluster2
@@ -33,27 +46,41 @@ configuration files.
    configuration files that reside under
    :file:`/etc/ood/config/clusters.d/{*}.yml`.
 
+
 #. For now let us test just a single cluster (in our example we use
    ``cluster1``, so you will need to replace it with the name of the cluster
    you configured):
 
-   .. code-block:: sh
+      .. rubric:: If you are using SCL, run the following command:
 
-      sudo su $USER -c 'scl enable ondemand -- bin/rake test:jobs:cluster1 RAILS_ENV=production'
-      # [sudo] password for user:
-      # Rails Error: Unable to access log file. Please ensure that /var/www/ood/apps/sys/dashboard/log/production.log exists and is writable (ie, make it writable for user and group: chmod 0664 /var/www/ood/apps/sys/dashboard/log/production.log). The log level has been raised to WARN and the output directed to STDERR until the problem is fixed.
-      # mkdir -p /home/user/test_jobs
-      # Testing cluster 'cluster1'...
-      # Submitting job...
-      # [2018-04-24 10:15:32 -0400 ]  INFO "execve = [{\"PBS_DEFAULT\"=>\"oak-batch.osc.edu\", \"LD_LIBRARY_PATH\"=>\"/opt/torque/lib64:/opt/rh/rh-nodejs6/root/usr/lib64:/opt/rh/rh-ruby24/root/usr/lib64\"}, \"/opt/torque/bin/qsub\", \"-N\", \"test_jobs_cluster1\", \"-S\", \"/bin/bash\", \"-o\", \"/users/appl/jnicklas/test_jobs/output_cluster1_2018-04-24T10:15:32-04:00.log\", \"-l\", \"walltime=00:01:00\", \"-j\", \"oe\"]"
-      # Got job id '10820525.oak-batch.osc.edu'
-      # Job has status of queued
-      # Job has status of queued
-      # Job has status of queued
-      # Job has status of queued
-      # Job has status of completed
-      # Test for 'cluster1' PASSED!
-      # Finished testing cluster 'cluster1'
+      .. code-block:: sh
+
+         sudo su $USER -c 'scl enable ondemand -- bin/rake test:jobs:cluster1 RAILS_ENV=production'
+
+      .. rubric:: If you are NOT using SCL, run the following command:
+
+      .. code-block:: sh
+
+         sudo su $USER -c 'source /opt/ood/ondemand/enable; bin/rake test:jobs:cluster1 RAILS_ENV=production'
+
+      .. rubric:: Results
+
+      .. code-block:: sh
+
+         # [sudo] password for user:
+         # Rails Error: Unable to access log file. Please ensure that /var/www/ood/apps/sys/dashboard/log/production.log exists and is writable (ie, make it writable for user and group: chmod 0664 /var/www/ood/apps/sys/dashboard/log/production.log). The log level has been raised to WARN and the output directed to STDERR until the problem is fixed.
+         # mkdir -p /home/user/test_jobs
+         # Testing cluster 'cluster1'...
+         # Submitting job...
+         # [2018-04-24 10:15:32 -0400 ]  INFO "execve = [{\"PBS_DEFAULT\"=>\"oak-batch.osc.edu\", \"LD_LIBRARY_PATH\"=>\"/opt/torque/lib64:/opt/rh/rh-nodejs6/root/usr/lib64:/opt/rh/rh-ruby24/root/usr/lib64\"}, \"/opt/torque/bin/qsub\", \"-N\", \"test_jobs_cluster1\", \"-S\", \"/bin/bash\", \"-o\", \"/users/appl/jnicklas/test_jobs/output_cluster1_2018-04-24T10:15:32-04:00.log\", \"-l\", \"walltime=00:01:00\", \"-j\", \"oe\"]"
+         # Got job id '10820525.oak-batch.osc.edu'
+         # Job has status of queued
+         # Job has status of queued
+         # Job has status of queued
+         # Job has status of queued
+         # Job has status of completed
+         # Test for 'cluster1' PASSED!
+         # Finished testing cluster 'cluster1'
 
    Please **ignore** the ``Rails Error:`` message as this is just a *warning*
    that doesn't affect your OnDemand installation in any way. We are currently
@@ -86,8 +113,16 @@ configuration files.
       provide these command line arguments as a string with the environment
       variable ``SUBMIT_ARGS`` as:
 
+      .. rubric:: If you are using SCL, run the following command:
+
       .. code-block:: sh
 
          sudo su $USER -c 'scl enable ondemand-- bin/rake test:jobs:cluster1 RAILS_ENV=production SUBMIT_ARGS="-A myaccount"'
+         
+      .. rubric:: If you are NOT using SCL, run the following command:
+
+      .. code-block:: sh
+
+         sudo su $USER -c 'source /opt/ood/ondemand/enable; bin/rake test:jobs:cluster1 RAILS_ENV=production SUBMIT_ARGS="-A myaccount"'
 
       Note that the ``SUBMIT_ARGS="..."`` is defined at the end of the command.

--- a/source/installation/resource-manager/test.rst
+++ b/source/installation/resource-manager/test.rst
@@ -22,7 +22,7 @@ configuration files.
 
 #. We will now list all available tasks that we can run:
 
-   .. rubric:: If your O/S is CentOS 7 or RHEL 7, run this command:
+   .. rubric:: If your operating system is CentOS 7 or RHEL 7, run this command:
 
    .. code-block:: sh
 
@@ -51,7 +51,7 @@ configuration files.
    ``cluster1``, so you will need to replace it with the name of the cluster
    you configured):
 
-      .. rubric:: If your O/S is CentOS 7 or RHEL 7, run this command:
+      .. rubric:: If your operating system is CentOS 7 or RHEL 7, run this command:
 
       .. code-block:: sh
 
@@ -113,7 +113,7 @@ configuration files.
       provide these command line arguments as a string with the environment
       variable ``SUBMIT_ARGS`` as:
 
-      .. rubric:: If your O/S is CentOS 7 or RHEL 7, run this command:
+      .. rubric:: If your operating system is CentOS 7 or RHEL 7, run this command:
 
       .. code-block:: sh
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/updateSlurmDoc/installation/resource-manager/test

Update slurm config documentation to reference additional commands if not using SCL



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201852664276197) by [Unito](https://www.unito.io)
