### PR TITLE
make install as source a 2nd header

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -30,7 +30,7 @@ means that it will need:
    installation/add-ldap
 
 Building From Source
-====================
+--------------------
 
 Building from source is left as an exercise to the reader. 
      


### PR DESCRIPTION


https://osc.github.io/ood-documentation-test/rm-source/

Because this section had a ==== it was the interpreted as having the same section heading as the rest of authentication and thus a part of the menu bar here. This makes it so it's not a part of the menu bar.

![image](https://user-images.githubusercontent.com/4874123/155008834-8647f094-280b-4d80-a48a-ea7a63d132ee.png)

