### PR TITLE
update app_root dev path to be consistent with what is actually in nginx_stage/lib/nginx_stage/configuration.rb

### DIFF
--- a/source/reference/commands/nginx-stage/commands/app.rst
+++ b/source/reference/commands/nginx-stage/commands/app.rst
@@ -80,7 +80,7 @@ installation.
      - :file:`/var/www/ood/apps/dev/{app_owner}/gateway/{app_name}`
    * - usr
      - :file:`/usr/{app_owner}/{app_name}/\*`
-     - :file:`/var/ww/ood/apps/usr/{app_owner}/gateway/{app_name}`
+     - :file:`/var/www/ood/apps/usr/{app_owner}/gateway/{app_name}`
    * - sys
      - :file:`/sys/{app_name}/\*`
      - :file:`/var/www/ood/apps/sys/{app_name}`

--- a/source/reference/commands/nginx-stage/commands/app.rst
+++ b/source/reference/commands/nginx-stage/commands/app.rst
@@ -77,7 +77,7 @@ installation.
      - File system path
    * - dev
      - :file:`/dev/{app_name}/\*`
-     - :file:`~{user}/ondemand/dev/{app_name}`
+     - :file:`/var/www/ood/apps/dev/{app_owner}/gateway/{app_name}`
    * - usr
      - :file:`/usr/{app_owner}/{app_name}/\*`
      - :file:`/var/ww/ood/apps/usr/{app_owner}/gateway/{app_name}`

--- a/source/reference/files/nginx-stage-yml.rst
+++ b/source/reference/files/nginx-stage-yml.rst
@@ -533,7 +533,7 @@ Configuration Options
      .. code-block:: yaml
 
         app_root:
-          dev: "~%{owner}/ondemand/dev/%{name}"
+          dev: "/var/www/ood/apps/dev/%{owner}/gateway/%{name}"
           usr: "/var/www/ood/apps/usr/%{owner}/gateway/%{name}"
           sys: "/var/www/ood/apps/sys/%{name}"
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation/develop/reference/files/nginx-stage-yml.html?highlight=app_root
https://osc.github.io/ood-documentation/develop/reference/commands/nginx-stage/commands/app.html?highlight=dev

**Add your description here**

The values listed as the default for for `app_root.dev` in the [doc for `nginx_stage.yml`](https://osc.github.io/ood-documentation/latest/reference/files/nginx-stage-yml.html?highlight=app_root) (`"~%{owner}/ondemand/dev/%{name}"`) and the [doc for the `nginx_stage app` command](https://osc.github.io/ood-documentation/latest/reference/commands/nginx-stage/commands/app.html?highlight=dev) (`~user/ondemand/dev/app_name`) do not match the apparent [actual default value](https://github.com/OSC/ondemand/blob/9f65f151d0cf2ffefa534c2ce428d8644d32c401/nginx_stage/lib/nginx_stage/configuration.rb#L468) (`'/var/www/ood/apps/dev/%{owner}/gateway/%{name}'`).

The old values appear to be a holdover from OOD 1.3 per [how-tos/app-development/enabling-development-mode.rst](https://github.com/OSC/ood-documentation/blob/develop/source/how-tos/app-development/enabling-development-mode.rst#make-everyone-a-developer-by-default-optional)

This PR updates the two outdated files with the current default value.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201879795823800) by [Unito](https://www.unito.io)
