### PR TITLE
typo: websockify_cmd

### DIFF
--- a/source/reference/files/submit-yml/vnc-bc-options.rst
+++ b/source/reference/files/submit-yml/vnc-bc-options.rst
@@ -30,7 +30,7 @@ All the options in :ref:`basic-bc-options` apply in addition to what's listed be
       vnc_clean: "..."
 
 
-.. describe:: websockfiy_cmd (String, "/opt/websockify/run")
+.. describe:: websockify_cmd (String, "/opt/websockify/run")
 
     the command to start websockify
 
@@ -39,7 +39,7 @@ All the options in :ref:`basic-bc-options` apply in addition to what's listed be
 
       .. code-block:: yaml
 
-        websockfiy_cmd: "/opt/websockify/run"
+        websockify_cmd: "/opt/websockify/run"
 
     Example
       the '/usr/bin/websockify' command


### PR DESCRIPTION
I believe this was only typo appearing here:

https://osc.github.io/ood-documentation/latest/reference/files/submit-yml/vnc-bc-options.html?highlight=websockfiy_cmd

reproducer:

1) go to the URL above
2) search for string "websockfiy_cmd"

IMO `websockfiy_cmd` should be `websockify_cmd`.
