### PR TITLE
Rewording a note and moving it up in sequence and adding a warning.

### DIFF
--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -87,12 +87,12 @@ software requirements:
 
        sudo apt install ondemand
 
+.. note::
+
+   If *authenticating against LDAP* or *wishing to evaluate OnDemand* using `ood` user, you **must install** `ondemand-dex` as 
+   described below. See :ref:`add-ldap` for details on configuration of LDAP and :ref:`start-services` for the `ood` user.
+
 #. (Optional) Install :ref:`authentication-dex` package
-
-   .. note::
-
-      If authenticating against LDAP or wishing to evaluate OnDemand using `ood` user, you must install `ondemand-dex`.
-      See :ref:`add-ldap` for details on configuration of LDAP.
 
    **RedHat/CentOS/Rocky only**
 
@@ -114,7 +114,7 @@ software requirements:
 
        sudo yum install ondemand-selinux
 
-.. note::
+.. warning::
 
    For some older systems, user ids (UID) may start at ``500`` and not the
    expected ``1000``. If this true for your system, you will need to modify the


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/improve-install-instructions/

**Add your description here**
Addresses #629.  Updated and moved the note above optional steps to call out the need of ondemand-dex for LDAP or OOD exploration and changed note at bottom to a warning given the risk of broken state. DNF has a symlink to yum in RHEL 8 so updating those instructions seemed redundant for what's there.