### PR TITLE
add example for bc_desktop into dashboard_pinned_apps

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -579,6 +579,8 @@ Full examples are below:
   # /etc/ood/config/ondemand.d/ondemand.yml
   pinned_apps:
     - sys/jupyter           # pin a specific system installed app called 'jupyter'
+    
+    - sys/bc_desktop/desk1  # pinned desktop app must contain exact desktop name - 'desk1'
  
     - 'sys/*'               # pin all system install apps. This also works for usr/* and dev/*
   


### PR DESCRIPTION
I think we could add proposed trick from https://discourse.openondemand.org/t/modified-apps-in-etc-ood-config-apps-not-showing-up-as-pinned/1528/4?u=jose-d as an example into this documentation page.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202160916434747) by [Unito](https://www.unito.io)
