### PR TITLE
update to sphinx 2.4.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Make Html
-        run: docker run --rm -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/docker-sphinx make html
+        run: docker run --rm -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/ood-doc-build:v2.0.0 make html
 
       - name: Publish to the test repo
         run: GITHUB_TOKEN=${{ secrets.OSC_WIAG_PUB_REPO_TOKEN }} /bin/bash push.sh "ood-documentation-test"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Currently all builds are generated using the
 built using the following command from the root of this repo:
 
 ```bash
-docker run --rm -i -t -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/docker-sphinx make html
+docker run --rm -i -t -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/ood-doc-build make html
 ```
 
 Or use the rake task added:

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ namespace :docker do
 
   desc "Build docs using docker"
   task :build do
-    exec 'docker run --rm -i -t -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/docker-sphinx make html'
+    exec 'docker run --rm -i -t -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/ood-doc-build make html'
   end
 end
 

--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -781,12 +781,8 @@ that lists all user quotas. The JSON schema for version `1` is given as:
      "version": 1,
      "timestamp": 1525361263,
      "quotas": [
-       {
-         ...
-       },
-       {
-         ...
-       }
+       {},
+       {}
      ]
    }
 
@@ -877,12 +873,8 @@ that lists all user balances. The JSON schema for version `1` is given as:
         "project_type": "project"
       },
       "balances": [
-        {
-          ...
-        },
-        {
-          ...
-        }
+        {},
+        {}
       ]
     }
 


### PR DESCRIPTION
This uses the image used to build documentation from which has
the incompatible sphinx 2.4. We'd need to backport this commit to
any release branch we update.

**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/update-spinx/

**Add your description here**



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202170489323172) by [Unito](https://www.unito.io)
