### PR TITLE
OIDC: add OIDCResponseType to the example config

### DIFF
--- a/source/authentication/oidc.rst
+++ b/source/authentication/oidc.rst
@@ -47,6 +47,7 @@ The following is an example :program:`ood-portal-generator` configuration file:
      OIDCPassRefreshToken: "On"
      OIDCPassClaimsAs: "environment"
      OIDCStripCookies: "mod_auth_openidc_session mod_auth_openidc_session_chunks mod_auth_openidc_session_0 mod_auth_openidc_session_1"
+     OIDCResponseType: "code"
 
 .. note::
 


### PR DESCRIPTION
* Explicitly add the OIDCResponseType configuration, to make users
  consider what value it should have. If the wrong configuration is
  used, OIDC authentication will fail.

**Motivation**

When testing this, we forgot to specify `OIDCResponseType` in the httpd24-httpd configurations which resulted in the wrong default value for our site. By adding the key into the configuration docs, perhaps other users will not forget to consider this.

The value in the configuration is the default value `"code"` as specified in the mod_auth_openidc upstream's comments: https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L213



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202283711841049) by [Unito](https://www.unito.io)
