### PR TITLE
enable newer image in latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Make Html
-        run: docker run --rm -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/docker-sphinx make html
+        run: docker run --rm -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/ood-doc-build:v2.0.0 make html
 
       - name: Publish to the test repo
         run: GITHUB_TOKEN=${{ secrets.OSC_WIAG_PUB_REPO_TOKEN }} /bin/bash push.sh "ood-documentation-test"

--- a/source/customization.rst
+++ b/source/customization.rst
@@ -761,12 +761,8 @@ that lists all user quotas. The JSON schema for version `1` is given as:
      "version": 1,
      "timestamp": 1525361263,
      "quotas": [
-       {
-         ...
-       },
-       {
-         ...
-       }
+       {},
+       {}
      ]
    }
 
@@ -857,12 +853,8 @@ that lists all user balances. The JSON schema for version `1` is given as:
         "project_type": "project"
       },
       "balances": [
-        {
-          ...
-        },
-        {
-          ...
-        }
+        {},
+        {}
       ]
     }
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/update-latest/

Note that this is going into `latest`. We need to update latest for Ubuntu stuff, but I would like to get `tabs` to work and for that I need this newer image to make the docs.
