### PR TITLE
fix build from source instructions

### DIFF
--- a/source/authentication/dex.rst
+++ b/source/authentication/dex.rst
@@ -21,7 +21,7 @@ Installing OnDemand Dex from source
 
 Requirements:
 
-- Go version 1.14.x with the ``go`` binary in ``PATH``
+- Go version 1.16.x with the ``go`` binary in ``PATH``
 - Git
 - Make
 
@@ -32,7 +32,7 @@ Build and install the ondemand-dex binary:
       GOPATH=$(go env GOPATH)
       go get github.com/dexidp/dex
       cd $GOPATH/src/github.com/dexidp/dex
-      make
+      make build
       sudo install -m 0755 bin/dex /usr/sbin/ondemand-dex
 
 Add the ``ondemand-dex`` user and group:


### PR DESCRIPTION
these are just what worked for me on ubuntu 20.04
https://github.com/OSC/ood-documentation/issues/701

https://osc.github.io/ood-documentation/latest/authentication/dex.html#installing-ondemand-dex-from-source

