### PR TITLE
Numerous updates to packages and install instructions

### DIFF
--- a/source/how-tos/app-development/interactive/setup/enable-reverse-proxy.rst
+++ b/source/how-tos/app-development/interactive/setup/enable-reverse-proxy.rst
@@ -122,12 +122,12 @@ Steps to Enable in Apache
    RHEL/CentOS 7:
      .. code-block:: sh
 
-        sudo systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
+        sudo systemctl try-restart httpd24-httpd.service
 
-   RHEL/Rocky 8:
+   RHEL/Rocky 8 & 9:
      .. code-block:: sh
 
-        sudo systemctl try-restart httpd.service htcacheclean.service
+        sudo systemctl try-restart httpd.service
 
    Ubuntu:
      .. code-block:: sh

--- a/source/how-tos/app-development/interactive/setup/enable-reverse-proxy.rst
+++ b/source/how-tos/app-development/interactive/setup/enable-reverse-proxy.rst
@@ -117,22 +117,7 @@ Steps to Enable in Apache
 
       sudo /opt/ood/ood-portal-generator/sbin/update_ood_portal
 
-#. Restart the Apache server to have the changes take effect:
-
-   RHEL/CentOS 7:
-     .. code-block:: sh
-
-        sudo systemctl try-restart httpd24-httpd.service
-
-   RHEL/Rocky 8 & 9:
-     .. code-block:: sh
-
-        sudo systemctl try-restart httpd.service
-
-   Ubuntu:
-     .. code-block:: sh
-
-        sudo systemctl try-restart apache2.service
+#. :ref:`Restart the Apache service <restart-apache>` to have the changes take effect:
 
 Verify it Works
 ---------------

--- a/source/how-tos/debug/debug-apache.rst
+++ b/source/how-tos/debug/debug-apache.rst
@@ -28,7 +28,7 @@ Restart services
           sudo systemctl try-restart httpd24-httpd
 
 
-      .. tab:: RHEL/Rocky 8
+      .. tab:: RHEL/Rocky 8 & 9
 
          .. code-block:: sh
 
@@ -65,7 +65,7 @@ Or you're using the wrong hostname in your browser.
 
           sudo /opt/rh/httpd24/root/sbin/httpd -S
 
-      .. tab:: RHEL/Rocky 8
+      .. tab:: RHEL/Rocky 8 & 9
 
          .. code-block:: sh
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -6,7 +6,7 @@ Installation
 The OnDemand host machine needs to be setup *similarly* to a login node. This
 means that it will need:
 
-- RedHat/CentOS 7+ or Ubuntu 20.04
+- RedHat/CentOS 7+ or Ubuntu 20.04 or Ubuntu 22.04
 - signed SSL certificate with corresponding intermediate certificate for your
   advertised OnDemand host name (e.g., ``ondemand.my_center.edu``)
 

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -35,7 +35,14 @@ Some operating systems use `Software Collections`_ to satisfy these.
 
          sudo dnf config-manager --set-enabled powertools
          sudo dnf install epel-release
-         sudo dnf module enable ruby:2.7 nodejs:14
+         sudo dnf module enable ruby:3.0 nodejs:14
+
+   .. tab:: RockyLinux 9
+
+      .. code-block:: sh
+
+         sudo dnf config-manager --set-enabled crb
+         sudo dnf install epel-release
 
    .. tab:: RHEL 7
 
@@ -53,19 +60,20 @@ Some operating systems use `Software Collections`_ to satisfy these.
 
    .. tab:: RHEL 8
 
-      .. warning::
+      .. code-block:: sh
 
-         You may also need to enable the *Optional* channel and
-         attach a subscription providing access to RHSCL to be able to use this
-         repository.
+         sudo dnf install epel-release
+         sudo dnf module enable ruby:3.0 nodejs:14
+         sudo subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+
+
+   .. tab:: RHEL 9
 
       .. code-block:: sh
 
-         sudo dnf config-manager --set-enabled powertools
          sudo dnf install epel-release
-         sudo dnf module enable ruby:2.7 nodejs:14
-         sudo subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-
+         sudo dnf module enable ruby:3.0 nodejs:14
+         sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
 
 2. Add repository and install
 -----------------------------
@@ -105,7 +113,7 @@ Some operating systems use `Software Collections`_ to satisfy these.
           sudo systemctl enable httpd24-httpd
 
 
-      .. tab:: RHEL/Rocky 8
+      .. tab:: RHEL/Rocky 8 & 9
 
          .. code-block:: sh
 

--- a/source/release-notes/v2.1-release-notes.rst
+++ b/source/release-notes/v2.1-release-notes.rst
@@ -11,7 +11,7 @@ v2.1 Release Notes
 Highlights in 2.1:
 
 - `Dynamic Javascript in BatchConnect Forms`_
-- `Ubuntu 20.04 packages`_
+- `EL9, Ubuntu 22.04 and Ubuntu 20.04 packages`_
 - `Dependency updates`_
 - `SELinux changes`_
 
@@ -61,6 +61,8 @@ Upgrade directions
 
       sudo dnf module reset nodejs
       sudo dnf module enable nodejs:14
+      sudo dnf module reset ruby
+      sudo dnf module enable ruby:3.0
 
 #. Update OnDemand
 
@@ -117,7 +119,7 @@ Upgrade directions
 
    .. code-block:: sh
 
-      sudo yum remove rh-nodejs12\*
+      sudo yum remove rh-nodejs12\* rh-ruby27\*
 
 
 Details
@@ -126,23 +128,30 @@ Details
 Dynamic Javascript in BatchConnect Forms
 ........................................
 
+EL9, Ubuntu 22.04 and Ubuntu 20.04 packages
+...........................................
 
-Ubuntu 20.04 packages
-.....................
-
-See :ref:`Install Software <install-software>` for instructions on how to install OnDemand using the new Ubuntu 20.04 packages.
+See :ref:`Install Software <install-software>` for instructions on how to install OnDemand using the new EL9, Ubuntu 22.04 and Ubuntu 20.04 packages.
 
 Dependency updates
 ..................
 
 This release updates the following dependencies:
 
+- Ruby 3.0
+
+  .. warning:: The change in Ruby version means any Ruby based apps that are not provided by the OnDemand RPM must be rebuilt.
+
+  .. note:: Ruby 2.7 is still supported and used by Ubuntu 20.04.
+
 - NodeJS 14
 
   .. warning:: The change in Node version means any Node based apps that are not provided by the OnDemand RPM must be rebuilt.
 
-- Passenger 6.0.11
-- NGINX 1.20.1
+- Passenger 6.0.14
+- NGINX 1.20.2
+- ondemand-dex 2.32.0
+- OnDemand package now depends on Python 3 instead of Python 2
 
 SELinux changes
 ...............

--- a/source/release-notes/v2.1-release-notes.rst
+++ b/source/release-notes/v2.1-release-notes.rst
@@ -140,7 +140,7 @@ This release updates the following dependencies:
 
 - Ruby 3.0
 
-  .. warning:: The change in Ruby version means any Ruby based apps that are not provided by the OnDemand RPM must be rebuilt.
+  .. warning:: The change in Ruby version means any Ruby based apps that are not provided by the OnDemand RPM must be rebuilt or supply their own ``bin/ruby`` to use the older version of ruby.
 
   .. note:: Ruby 2.7 is still supported and used by Ubuntu 20.04.
 


### PR DESCRIPTION
Document EL9 support, fixes #689
Document Ubuntu 20.04 and 22.04 support, fixes #688
Document Ruby 3.0 upgrade, fixes #686
Document updated ondemand-dex in release notes, fixes #684
Document python3 dependency, fixes #679
Remove references to htcacheclean as removed from ondemand repo

**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/el9/

**Add your description here**
