### PR TITLE
Add warning about using partition as user-defined attribute in app forms

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -474,6 +474,13 @@ The following configuration file
 
 defines a session context attribute called ``my_module_version``.
 
+.. warning::
+
+   Do not use ``partition`` as attribute name within the form. The (Ruby)
+   object created by the form is of type enumerable and ``partition`` is
+   method of that particular class. This causes the value set in the form not
+   being correctly passed to the submit script.
+
 After modifying the ``form.yml`` click *Launch My App* from the Dashboard
 sandbox app list and you will see an empty text box with the label "My Module
 Version". The user can input any value here and launch the Interactive App


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:
https://osc.github.io/ood-documentation-test/develop/how-tos/app-development/interactive/form.html
**Add your description here**

This is an attempt to fix #707 

Maybe the explanation is not totally accurate, I was not sure about how much detail to put in the warning.

Even if there is a section that already mentions how to [define partitions](https://osc.github.io/ood-documentation-test/develop/tutorials/tutorials-interactive-apps/add-custom-queue.html) having the explicit warning might help some other users. Would it make sense to re-issue the warning in the [that](https://osc.github.io/ood-documentation-test/develop/tutorials/tutorials-interactive-apps/add-custom-queue.html#add-custom-queues-partitions) section too ?