### PR TITLE
[HOLD] Ubuntu latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Make Html
-        run: docker run --rm -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/docker-sphinx make html
+        run: docker run --rm -v "${PWD}:/doc" -u "$(id -u):$(id -g)" ohiosupercomputer/ood-doc-build:v2.0.0 make html
 
       - name: Publish to the test repo
         run: GITHUB_TOKEN=${{ secrets.OSC_WIAG_PUB_REPO_TOKEN }} /bin/bash push.sh "ood-documentation-test"

--- a/source/authentication/dex.rst
+++ b/source/authentication/dex.rst
@@ -102,6 +102,20 @@ Iptables example:
       $ sudo iptables -I INPUT -p tcp -m tcp --dport 5554 -j ACCEPT
       $ sudo iptables-save > /etc/sysconfig/iptables
 
+Configuring OnDemand Dex behind Apache reverse proxy
+----------------------------------------------------
+
+The OnDemand Dex service can be proxied behind the Apache web service using a reverse proxy.
+This would mean port 5554 or 5556 would not need to be opened.
+
+Enabling the OnDemand Dex reverse proxy logic will force Dex to listen only on ``localhost`` and only
+via HTTP.
+
+Example of configuration change to put Dex behind the Apache reverse proxy
+
+   .. code-block:: yaml
+
+      dex_uri: /dex
 
 Configuring OnDemand Dex for LDAP
 ---------------------------------

--- a/source/conf.py
+++ b/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinxcontrib.httpdomain',
     'sphinxcontrib.plantuml',
+    'sphinx_tabs.tabs'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/customization.rst
+++ b/source/customization.rst
@@ -761,12 +761,8 @@ that lists all user quotas. The JSON schema for version `1` is given as:
      "version": 1,
      "timestamp": 1525361263,
      "quotas": [
-       {
-         ...
-       },
-       {
-         ...
-       }
+       {},
+       {}
      ]
    }
 
@@ -857,12 +853,8 @@ that lists all user balances. The JSON schema for version `1` is given as:
         "project_type": "project"
       },
       "balances": [
-        {
-          ...
-        },
-        {
-          ...
-        }
+        {},
+        {}
       ]
     }
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -6,7 +6,7 @@ Installation
 The OnDemand host machine needs to be setup *similarly* to a login node. This
 means that it will need:
 
-- RedHat/CentOS 7+
+- RedHat/CentOS 7+ or Ubuntu 18.04+
 - a common user/group database, e.g., LDAP + NSS
 - a common host file list
 - the resource manager (e.g., Torque, Slurm, or LSF) client binaries and

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -6,7 +6,7 @@ Installation
 The OnDemand host machine needs to be setup *similarly* to a login node. This
 means that it will need:
 
-- RedHat/CentOS 7+ or Ubuntu 18.04+
+- RedHat/CentOS 7-8 or Ubuntu 18.04-20.04
 - a common user/group database, e.g., LDAP + NSS
 - a common host file list
 - the resource manager (e.g., Torque, Slurm, or LSF) client binaries and

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -80,7 +80,7 @@ software requirements:
 
          .. code-block:: sh
 
-            sudo apt install apt-transport-https ca-certificates
+            sudo apt install apt-transport-https ca-certificates wget
             wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.0_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.0_all.deb
             sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.0_all.deb
             sudo apt update

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -1,7 +1,7 @@
 .. _install-software:
 
-Install Software From RPM
-=========================
+Install Software From Package
+=============================
 
 We will use `Software Collections`_ to satisfy majority of the following
 software requirements:
@@ -16,56 +16,77 @@ software requirements:
    This tutorial is run from the perspective of an account that has
    :command:`sudo` access but is not root.
 
-#. Enable the dependency repositories **on CentOS/RHEL 7 only**:
+1. Enable the dependency repositories:
 
-   CentOS 7
-     .. code-block:: sh
+.. tabs::
 
-        sudo yum install centos-release-scl epel-release
+   .. tab:: CentOS 7
 
-   RHEL 7
-     .. code-block:: sh
+      .. code-block:: sh
 
-        sudo yum install epel-release
-        sudo subscription-manager repos --enable=rhel-server-rhscl-7-rpms
-        # Repository 'rhel-server-rhscl-7-rpms' is enabled for this system.
+         sudo yum install centos-release-scl epel-release
 
-   .. warning::
 
-      For **RedHat** you may also need to enable the *Optional* channel and
-      attach a subscription providing access to RHSCL to be able to use this
-      repository.
+   .. tab:: RockyLinux 8
 
-#. Enable dnf modules and repositories for dependencies **on CentOS/RHEL 8 only**:
+      .. code-block:: sh
 
-    .. code-block:: sh
+         sudo dnf config-manager --set-enabled powertools
+         sudo dnf install epel-release
+         sudo dnf module enable ruby:2.7 nodejs:14
 
-       dnf module enable ruby:2.7
-       dnf module enable nodejs:12
+   .. tab:: RHEL 7
 
-    **CentOS 8 only**
+      .. warning::
 
-    .. code-block:: sh
+         You may also need to enable the *Optional* channel and
+         attach a subscription providing access to RHSCL to be able to use this
+         repository.
 
-       sudo dnf config-manager --set-enabled powertools
+      .. code-block:: sh
 
-    **RedHat 8 only**
+         sudo yum install epel-release
+         sudo subscription-manager repos --enable=rhel-server-rhscl-7-rpms
 
-    .. code-block:: sh
 
-       sudo subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+   .. tab:: RHEL 8
 
-#. Add Open OnDemand's repository hosted by the `Ohio Supercomputer Center`_:
+      .. warning::
 
-     .. code-block:: sh
+         You may also need to enable the *Optional* channel and
+         attach a subscription providing access to RHSCL to be able to use this
+         repository.
 
-        sudo yum install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-1.noarch.rpm
+      .. code-block:: sh
 
-#. Install OnDemand and all of its dependencies:
+         sudo dnf config-manager --set-enabled powertools
+         sudo dnf install epel-release
+         sudo dnf module enable ruby:2.7 nodejs:14
+         sudo subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 
-   .. code-block:: sh
+2. Add Open OnDemand's repository hosted by the `Ohio Supercomputer Center`_ and install:
 
-      sudo yum install ondemand
+   .. tabs::
+
+      .. tab:: yum/dnf
+
+         .. code-block:: sh
+
+            sudo yum install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-1.noarch.rpm
+
+            sudo yum install ondemand
+
+
+      .. tab:: apt
+
+         .. code-block:: sh
+
+            sudo apt install apt-transport-https ca-certificates
+            wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.0_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.0_all.deb
+            sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.0_all.deb
+            sudo apt update
+
+            sudo apt install ondemand
 
 #. (Optional) Install :ref:`authentication-dex` package
 
@@ -74,15 +95,34 @@ software requirements:
       If authenticating against LDAP or wishing to evaluate OnDemand using `ood` user, you must install `ondemand-dex`.
       See :ref:`add-ldap` for details on configuration of LDAP.
 
-   .. code-block:: sh
+   .. tabs::
 
-      sudo yum install ondemand-dex
+      .. tab:: yum/dnf
+
+         .. code-block:: sh
+
+            sudo yum install ondemand-dex
+
+
+      .. tab:: apt
+
+         .. code-block:: sh
+
+            sudo apt install ondemand-dex
 
 #. (Optional) Install OnDemand SELinux support if you have SELinux enabled. For details see :ref:`ood_selinux`
 
-   .. code-block:: sh
+   .. tabs::
 
-      sudo yum install ondemand-selinux
+      .. tab:: yum/dnf
+
+         .. code-block:: sh
+
+            sudo yum install ondemand-selinux
+
+      .. tab:: apt
+
+          Not available for Debian systems.
 
 .. note::
 

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -59,7 +59,6 @@ software requirements:
 
       .. code-block:: sh
 
-         sudo dnf config-manager --set-enabled powertools
          sudo dnf install epel-release
          sudo dnf module enable ruby:2.7 nodejs:14
          sudo subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms

--- a/source/installation/start-apache.rst
+++ b/source/installation/start-apache.rst
@@ -9,17 +9,29 @@ Please see section :ref:`add-ldap` for a more advanced and recommended authentic
 
 #. Start the Apache HTTP Server:
 
-   CentOS/RHEL 7
-     .. code-block:: sh
+   .. tabs::
 
-        sudo systemctl start httpd24-httpd
-        sudo systemctl enable httpd24-httpd
+      .. tab:: RHEL/CentOS 7
 
-   CentOS/RHEL 8
-     .. code-block:: sh
+        .. code-block:: sh
 
-        sudo systemctl start httpd
-        sudo systemctl enable httpd
+          sudo systemctl start httpd24-httpd
+          sudo systemctl enable httpd24-httpd
+
+
+      .. tab:: RHEL/Rocky 8
+
+         .. code-block:: sh
+
+          sudo systemctl start httpd
+          sudo systemctl enable httpd
+
+      .. tab:: Ubuntu
+
+         .. code-block:: sh
+
+          sudo systemctl start apache2
+          sudo systemctl enable apache2
 
    .. warning::
 
@@ -31,7 +43,6 @@ Please see section :ref:`add-ldap` for a more advanced and recommended authentic
 
    If using the default OnDemand authentication mechanism, you must start the ``ondemand-dex`` service.
 
-   CentOS/RHEL 7 & 8
      .. code-block:: sh
 
         sudo systemctl start ondemand-dex

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -1131,6 +1131,26 @@ to ``null`` will disable this feature.
             OIDCPassIDTokenAs: serialized
             OIDCPassRefreshToken: On
 
+.. describe:: dex_uri (String, null, false)
+
+     The Dex URI used behind the Apache reverse proxy.
+     Setting this value to some path will result in Dex listening on local host
+     as well as only using HTTP for proxied communication.
+
+     Default
+       The default value is null
+
+       .. code-block:: yaml
+
+          dex_uri: null
+
+     Example
+       Enable Dex URI and Dex behind a reverse proxy
+
+       .. code-block:: yaml
+
+          dex_uri: /dex
+
 .. describe:: dex (Hash, null, false)
 
      The Hash to define Dex configurations.


### PR DESCRIPTION
We need to hold this until ubuntu packages are actually available to folks.

https://osc.github.io/ood-documentation-test/ubuntu-latest/

This adds Ubuntu install instructions to `latest`. It's on hold because they're not quite available yet.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202701641402742) by [Unito](https://www.unito.io)
