### PR TITLE
OnDemand 2.0 only supports NodeJS 12

### DIFF
--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -33,7 +33,7 @@ software requirements:
 
          sudo dnf config-manager --set-enabled powertools
          sudo dnf install epel-release
-         sudo dnf module enable ruby:2.7 nodejs:14
+         sudo dnf module enable ruby:2.7 nodejs:12
 
    .. tab:: RHEL 7
 
@@ -60,7 +60,7 @@ software requirements:
       .. code-block:: sh
 
          sudo dnf install epel-release
-         sudo dnf module enable ruby:2.7 nodejs:14
+         sudo dnf module enable ruby:2.7 nodejs:12
          sudo subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 
 2. Add Open OnDemand's repository hosted by the `Ohio Supercomputer Center`_ and install:


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/fix-nodejs/

**Add your description here**

https://github.com/OSC/ondemand/issues/2261