### PR TITLE
add note for apache admins

### DIFF
--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -16,6 +16,12 @@ software requirements:
    This tutorial is run from the perspective of an account that has
    :command:`sudo` access but is not root.
 
+..  tip::
+
+  If you are an administrator responsible for Open OnDemand, you are now an administrator of
+  Apache Httpd as well.  As such, you should get comfortable with it as from time to time you will
+  have to troubleshoot it.
+
 1. Enable the dependency repositories:
 
 .. tabs::

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -16,7 +16,7 @@ software requirements:
    This tutorial is run from the perspective of an account that has
    :command:`sudo` access but is not root.
 
-..  tip::
+..  warning::
 
   If you are an administrator responsible for Open OnDemand, you are now an administrator of
   Apache Httpd as well.  As such, you should get comfortable with it as from time to time you will


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/apache-admin/

This adds a note in install package page to stressing that they're now apache httpd admins too.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202989013494989) by [Unito](https://www.unito.io)
