### PR TITLE
Add missing comma in dynamic-form-widgets.rst

### DIFF
--- a/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
+++ b/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
@@ -93,7 +93,7 @@ instructs the webpage to hide the ``cuda_version`` when the ``standard``
       widget: select
       options:
         - [ 
-            'standard', 'standard' 
+            'standard', 'standard',
             data-hide-cuda-version: true
           ]
         - 'gpu'


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/develop/how-tos/app-development/interactive/dynamic-form-widgets.html

Adding a missing comma to the YAML setup for the "Hiding entire elements" section. Without the comma, a syntax error is generated and the app form will fail to load.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203503648119638) by [Unito](https://www.unito.io)
