### PR TITLE
Removing pipenv rake tasks and readme instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,46 +53,6 @@ Or use the rake task added:
 rake docker:build
 ```
 
-#### pipenv
-
-If you don't want to use Docker, you can also use pipenv.
-
-1. Ensure plantuml and graphviz are installed:
-
-    ```bash
-    # on OS X
-    brew install plantuml
-    brew install graphviz
-    ```
-
-2. Install pipenv and use it to install dependencies in same directory:
-
-    ```bash
-    pip install -g pipenv
-
-    # then in the documentation root directory:
-    WORKDIR=/doc PIPENV_VENV_IN_PROJECT=1 pipenv install
-
-    # or using handy rake task:
-    rake pipenv:install
-    ```
-
-When building the docs, run this command:
-
-```bash
-WORKDIR=/doc PIPENV_VENV_IN_PROJECT=1 pipenv run make html
-```
-
-or use the rake task:
-
-```bash
-rake pipenv:build
-
-# or
-
-rake build
-```
-
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/Rakefile
+++ b/Rakefile
@@ -4,22 +4,6 @@ task :default do
   system "rake --tasks"
 end
 
-namespace :pipenv do
-  desc "Build docs using pipenv"
-  task :build do
-    exec 'WORKDIR=/doc PIPENV_VENV_IN_PROJECT=1 pipenv run make html'
-  end
-
-  task :clean do
-    exec 'WORKDIR=/doc PIPENV_VENV_IN_PROJECT=1 pipenv run make clean'
-  end
-
-  desc "Install pipenv dependencies"
-  task :install do
-    exec 'WORKDIR=/doc PIPENV_VENV_IN_PROJECT=1 pipenv install'
-  end
-end
-
 namespace :docker do
 
   desc "Build docs using docker"


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:
remove-pipenv-rake-and-instructions
https://osc.github.io/ood-documentation-test/BRANCH-NAME/

**Add your description here**
Removing the `pipenv` instructions and `rake` tasks.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203558086887121) by [Unito](https://www.unito.io)
