### PR TITLE
allow for wider pages

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -30,6 +30,10 @@ span.c1 {
     color: #404040;
 }
 
+.wy-nav-content {
+  max-width: 80% !important;
+}
+
 /* override table width restrictions */
 @media screen and (min-width: 767px) {
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/wider/

This allows the content to take up more width on he screen.  We have several spots that overflow and this is to help that bit look nicer but also just to use more of the screen as that half screen content seemed weird.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203746168281793) by [Unito](https://www.unito.io)
