### PR TITLE
add docs for clearing bc app directories

### DIFF
--- a/source/reference/files/ondemand-d-ymls.rst
+++ b/source/reference/files/ondemand-d-ymls.rst
@@ -357,6 +357,52 @@ Configuration Properties
 
       bc_dynamic_js: true
 
+.. _bc_clean_old_dirs:
+.. describe:: bc_clean_old_dirs(Bool, false)
+
+  Interactive Apps create a new directory ``~/ondemand/data/sys/dashboard/batch_connect/...`` every time
+  the application is launched.  Over time users may create many directories that hold essentially old
+  and useless data.
+
+  When enabled, the system will remove every directory that is older than 30 days.
+  See ``bc_clean_old_dirs_days`` below to change the time range. You may wish to keep
+  directories for longer or shorter intervals.
+
+  Default
+    False. Never delete these directories.
+
+    .. code-block:: yaml
+
+      bc_clean_old_dirs: false
+
+  Example
+    Delete these directories after 30 days.
+
+    .. code-block:: yaml
+
+      bc_clean_old_dirs: true
+
+.. describe:: bc_clean_old_dirs_days(Integer, 30)
+
+  If you have ``bc_clean_old_dirs`` above enabled, the system will clean every directory that
+  is older than 30 days. This configuration specifies how old a directory (in days) must be to
+  be removed.
+
+  The system checks creation time, not modification time.
+
+  Default
+    Delete these directories after 30 days if ``bc_clean_old_dirs`` is enabled.
+
+    .. code-block:: yaml
+
+      bc_clean_old_dirs_days: 30
+
+  Example
+    Delete these directories after 15 days if ``bc_clean_old_dirs`` is enabled.
+
+    .. code-block:: yaml
+
+      bc_clean_old_dirs_days: 15
 
 .. describe:: host_based_profiles (Bool, false)
 

--- a/source/release-notes/v2.1-release-notes.rst
+++ b/source/release-notes/v2.1-release-notes.rst
@@ -15,6 +15,7 @@ Highlights in 2.1:
 - `Automatic Form Options`_
 - `Support for remote files`_
 - `Quick Launch Apps`_
+- `Deleting old interactive app directories`_
 - `Dependency updates`_
 - `SELinux changes`_
 
@@ -172,6 +173,17 @@ These launch with 1 click from the user and do not allow for choices. I.e., the 
 is never presented with a form to fill out, the app simply launches when clicked.
 
 See the documentation for :ref:`quick-launch-apps` for more information.
+
+Deleting old interactive app directories
+........................................
+
+2.1 provides a mechanism to automatically delete all the directories that interactive
+applications create in ``~/ondemand/data/sys/dashboard/batch_connect/...`` after some
+time period. The system provides two options for this:  One to enable the feature
+altogether and the other is to specify how old a directory must be to be removed.
+
+See :ref:`the configuration options for removing old directories <bc_clean_old_dirs>`
+for more details.
 
 Dependency updates
 ..................


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/docs-for-bc-removal/

This adds documentation for `bc_clean_old_dirs` and `bc_clean_old_dirs_days`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203810490848224) by [Unito](https://www.unito.io)
