### PR TITLE
update ACCESS IdP docs

### DIFF
--- a/source/authentication/nsf-access.rst
+++ b/source/authentication/nsf-access.rst
@@ -5,17 +5,19 @@ NSF ACCESS
 
 If your site is a part of the `National Science Foundation`_'s (NSF)
 `ACCESS`_ program (formerley `XSEDE`_) you can use their Identity Provider (IDP)
-`CI Logon`_ to authenticate users for your Open OnDemand instance.
+to authenticate users for your Open OnDemand instance.
 
 OIDC Client Registration
 ************************
 
 You should read the `ACCESS IDP documentation`_ on how to register your Open OnDemand
 instance as an Open ID Connect (OIDC) client.
+ACCESS uses `CILogon`_ to provide a bridge from campus authentication, via the InCommon Federation,
+to OAuth/OIDC-based research cyberinfrastructure (CI).
 
 Once you've registered your Open OnDemand instance, you can then configure it accordingly.
 Since `ACCESS`_ uses Open ID Connect (OIDC) you can see our :ref:`oidc documentation <authentication-oidc>`
-for more details on how to configure Open OnDemand with what CI Logon has provided in
+for more details on how to configure Open OnDemand with what CILogon has provided in
 registering your application.
 
 Here's an example you can use to get started. Note that ``oidc_client_id`` and ``oidc_client_secret``
@@ -28,8 +30,8 @@ are commented out because they are specific to your site.
   oidc_provider_metadata_url: "https://cilogon.org/.well-known/openid-configuration"
   # oidc_client_id: "cilogon:/client_id/..."
   # oidc_client_secret: "..."
-  oidc_remote_user_claim: "eppn"
-  oidc_scope: "openid email org.cilogon.userinfo"
+  oidc_remote_user_claim: "sub"
+  oidc_scope: "openid email profile org.cilogon.userinfo"
   oidc_session_inactivity_timeout: 28800
   oidc_session_max_duration: 28800
   oidc_state_max_number_of_cookies: "10 true"
@@ -47,12 +49,10 @@ Shibboleth and InCommon
 If your campus already runs Shibboleth authentication, you have an alternative to the Open ID Connect
 configuration above.
 
-`CI Logon`_ provides a bridge from campus authentication, via the InCommon Federation,
-to certificate-based and OAuth/OIDC-based research cyberinfrastructure (CI).
-
-The SAML metadata for idp.access-ci.org is not yet published by InCommon. Please manually fetch the
-metadata from https://identity.access-ci.org/access-metadata.xml and configure it in a local file
-until we can complete the InCommon publication process.
+The SAML metadata for idp.access-ci.org is published by InCommon and can be downloaded using the 
+Metadata Query (MDQ) Service from https://mdq.incommon.org/entities/https%3A%2F%2Faccess-ci.org%2Fidp . 
+Alternatively, you can download the metadata from https://identity.access-ci.org/access-metadata.xml 
+and configure it in a local file.
 
 See our :ref:`shibboleth documentation <authentication-shibboleth>` for more information on
 Shibboleth authentication.
@@ -94,7 +94,7 @@ the local user given the ACCESS username.
 .. _National Science Foundation: https://www.nsf.gov/
 .. _ACCESS: https://access-ci.org/
 .. _XSEDE: https://www.xsede.org/
-.. _ACCESS IDP documentation: https://identity.access-ci.org/
-.. _CI Logon: https://www.cilogon.org/faq
-.. _access-oauth-mapfile: https://software.xsede.org/production/access-oauth-mapfile/INSTALL
+.. _ACCESS IDP documentation: https://identity.access-ci.org/about-access-idp
+.. _CILogon: https://www.cilogon.org/faq
+.. _access-oauth-mapfile: https://github.com/access-ci-org/access-oauth-mapfile
 .. _user_map_cmd: ood-portal-generator-user-map-cmd


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/latest/authentication/nsf-access.html

* Link directly to the ACCESS IdP docs rather than the ACCESS IAM landing page.
* Reference CILogon in the OIDC section, not the SAML section.
* Update OIDC example configuration to use recommended oidc_remote_user_claim and oidc_scope values.
* SAML metadata is now published by InCommon.
* Update link for access-oauth-mapfile.