### PR TITLE
auto_modules is plural

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -192,9 +192,9 @@ auto_primary_group
   This will automatically set the `OodCore::Job::Script#accounting_id`_ to the
   primary group of the user.  No choice will be given to the user.
 
-auto_module_<MODULE>
+auto_modules_<MODULE>
   This will generate a list of modules in a ``select`` widget.
-  For example ``auto_module_matlab`` will automatically populate a dropdown
+  For example ``auto_modules_matlab`` will automatically populate a dropdown
   list of every single ``matlab`` version available.
 
   See :ref:`the module directory configuration <module_file_dir>` on how to enable

--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -195,8 +195,17 @@ auto_primary_group
 auto_modules_<MODULE>
   This will generate a list of modules in a ``select`` widget.
   For example ``auto_modules_matlab`` will automatically populate a dropdown
-  list of every single ``matlab`` version available.
+  list of every single ``matlab`` version available, including the default
+  version.
+  
+  To disable the default version, use the ``attributes`` field like so:
+  
+  .. code-block:: yaml
 
+     attributes:
+       auto_modules_matlab:
+         default: false
+  
   See :ref:`the module directory configuration <module_file_dir>` on how to enable
   the cluster module files that need to be read.
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/BRANCH-NAME/

The `auto_modues` feature is plural not singular.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203859845799941) by [Unito](https://www.unito.io)
