### PR TITLE
Updates after moving announcement_path to UserConfiguration

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -54,6 +54,8 @@ Because the announcement is rendered via ERB you can do some interesting things,
 
 .. note:: Warnings about the announcement file being missing may be present in users' nginx logs. Despite the warning the Dashboard will still function normally without those files being present.
 
+   The file path for the announcement message can be customize using configuration properties, see :ref:`OnDemand configuration documentation <ondemand-d-ymls>`.
+
 .. _motd_customization:
 
 Message of the Day (MOTD)
@@ -90,7 +92,7 @@ You can customize the logo, favicon, title, and navbar colors of OnDemand.
    :align: center
 
 
-We recommend setting these values using the :ref:`OnDemand configuration properties <ondemand-d-ymls>`.
+We recommend setting these values using the `:ref:`OnDemand configuration properties <ondemand-d-ymls>`.`
 Currently only the dashboard uses the colors in the navbar.
 
 .. list-table:: Branding

--- a/source/reference/files/ondemand-d-ymls.rst
+++ b/source/reference/files/ondemand-d-ymls.rst
@@ -381,6 +381,28 @@ Configuration Properties with profile support
 
       public_url: "/public/resources"
 
+.. describe:: announcement_path (Array<String>, ['/etc/ood/config/announcement.md', '/etc/ood/config/announcement.yml', '/etc/ood/config/announcements.d'])
+
+  The file or directory path to load announcement messages from.
+
+  Default
+    The default files are: ``/etc/ood/config/announcement.md``, ``/etc/ood/config/announcement.yml``, and ``/etc/ood/config/announcements.d``
+
+    .. code-block:: yaml
+
+      announcement_path:
+        - "/etc/ood/config/announcement.md"
+        - "/etc/ood/config/announcement.yml"
+        - "/etc/ood/config/announcements.d"
+
+
+  Example
+    Use ``/etc/ood/config/announcement.team1.d/`` as the path to load announcements.
+
+    .. code-block:: yaml
+
+      announcement_path: "/etc/ood/config/announcement.team1.d/"
+
 .. _nav_categories:
 .. describe:: nav_categories (Array<String>, ['Apps', 'Files', 'Jobs', 'Clusters', 'Interactive Apps'])
 


### PR DESCRIPTION
Minor updates after moving the `announcement_path` property to the `UserConfiguration` object

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204064219096821) by [Unito](https://www.unito.io)
