### PR TITLE
correct the systemd file used for ood-portal

### DIFF
--- a/source/reference/commands/ood-portal-generator.rst
+++ b/source/reference/commands/ood-portal-generator.rst
@@ -97,8 +97,8 @@ Options
    .. warning::
       The systemd file for Apache will run the update_ood_portal script with defaults
       and will not use a different file, rendering this option obsolete unless you also
-      modify systemd config (``/etc/systemd/system/httpd24-httpd.service.d/ood.conf`` in
-      RHEL 7, ``/etc/systemd/system/httpd.service.d/ood.conf`` in RHEL 8).
+      modify systemd config (``/etc/systemd/system/httpd24-httpd.service.d/ood-portal.conf`` in
+      RHEL 7, ``/etc/systemd/system/httpd.service.d/ood-portal.conf`` in RHEL 8).
 
 .. option:: -t <template>, --template <template>
 
@@ -117,7 +117,7 @@ Options
    .. warning::
       The systemd file for Apache will run the update_ood_portal script with defaults
       and will not use a different file, rendering this option obsolete unless you also
-      modify systemd config (``/etc/systemd/system/httpd24-httpd.service.d/ood.conf`` in
-      RHEL 7, ``/etc/systemd/system/httpd.service.d/ood.conf`` in RHEL 8).
+      modify systemd config (``/etc/systemd/system/httpd24-httpd.service.d/ood-portal.conf`` in
+      RHEL 7, ``/etc/systemd/system/httpd.service.d/ood-portal.conf`` in RHEL 8).
 
 .. _apache configuration: https://httpd.apache.org/docs/2.4/configuring.html


### PR DESCRIPTION
the systemd file specified was the ood one not the ood-portal one where these options reside

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204136607995597) by [Unito](https://www.unito.io)
