### PR TITLE
add a note about dropping ubuntu 18 support

### DIFF
--- a/source/release-notes/v3.0-release-notes.rst
+++ b/source/release-notes/v3.0-release-notes.rst
@@ -69,6 +69,13 @@ Details of administrative changes
 Breaking Changes
 ................
 
+Support for Ubuntu 18.04 has been dropped.
+******************************************
+
+Support for Ubuntu 18.04 has been dropped because the platform has
+upgraded to Ruby on Rails 6.1. This version  is not compatible with
+Ruby 2.5 which is what Ubuntu 18.04 has.
+
 context.json file locations have changed
 ****************************************
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/drop-ubuntu-18/

Adds a note in the release notes for dropping ubuntu 18 support.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204333656365026) by [Unito](https://www.unito.io)
