### PR TITLE
use osc-bot to push instead of gh-actions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -16,13 +16,13 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}
           fetch-depth: 0
 
       - name: Merge Branches
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config --global user.name ${{ secrets.OSC_ROBOT_GH_USER }}
+          git config --global user.email ${{ secrets.OSC_ROBOT_GH_USER_EMAIL }}
           git fetch
           git checkout latest
           git pull


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/BRANCH-NAME/

This updates the sync action to use osc-bot user instead of github actions because `develop` has protections on it.
