### PR TITLE
Plain http

### DIFF
--- a/source/installation/add-ssl.rst
+++ b/source/installation/add-ssl.rst
@@ -7,15 +7,6 @@ The SSL protocol provides for a secure channel of communication between the
 user's browser and the Open OnDemand portal.  It is recommended that you secure
 your Apache server by adding these configurations.
 
-.. warning::
-
-    Open OnDemand expects secure (https) traffic by default. If you do
-    not add SSL to your Apache server you will have to follow FIXME-LINK-NEEDED
-    to enable some (if not most) functionality.
-
-    This is not recommended as someone on your network could see your traffic in
-    plain text, including passwords.
-
 Requirements:
 
 - A server name that points to the Open OnDemand server (``ondemand.my_center.edu``).

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -143,7 +143,7 @@ Some operating systems use `Software Collections`_ to satisfy these.
 
 Now that Open OnDemand is installed and Apache is running, it should be serving
 a public page telling you to come back here and setup authentication.  If this
-is the case - then you need to :ref:`add authentication <authentication>` and :ref:`secure your apache <add-ssl>`.
+is the case - then you should :ref:`secure your apache <add-ssl>` then :ref:`add authentication <authentication>`.
 You may also want to :ref:`enable SELinux <modify-system-security>`.
 
 If you're seeing the default apache page (Ubuntu users will) you will have to :ref:`debug virtualhosts <show-virtualhosts>`

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -143,7 +143,7 @@ Some operating systems use `Software Collections`_ to satisfy these.
 
 Now that Open OnDemand is installed and Apache is running, it should be serving
 a public page telling you to come back here and setup authentication.  If this
-is the case - then you should :ref:`secure your apache <add-ssl>` then :ref:`add authentication <authentication>`.
+is the case - then you need to :ref:`add authentication <authentication>` and :ref:`secure your apache <add-ssl>`.
 You may also want to :ref:`enable SELinux <modify-system-security>`.
 
 If you're seeing the default apache page (Ubuntu users will) you will have to :ref:`debug virtualhosts <show-virtualhosts>`


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/plain-http/

This PR does 2 things
* re-orders the instructions on the install page for a little more clarity
* removes the warning around https traffic as it no longer applies.
