### PR TITLE
tweak install instructions around inital setup

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -52,7 +52,6 @@ These are institutions who were early adopters or provided HPC resources for dev
 
    requirements
    installation
-   authentication
    installation/add-cluster-config
    how-tos/app-development/interactive/setup
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -23,8 +23,9 @@ Sites may reconfigure their deployment to allow for plain text traffic see FIXME
    :numbered: 1
 
    installation/install-software
-   installation/modify-system-security
+   authentication
    installation/add-ssl
+   installation/modify-system-security
 
 Building From Source
 --------------------

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -142,8 +142,14 @@ Some operating systems use `Software Collections`_ to satisfy these.
 ----------------------
 
 Now that Open OnDemand is installed and Apache is running, it should be serving
-a public page telling you to come back here and setup authentication.  If this
-is the case - then you should :ref:`secure your apache <add-ssl>` then :ref:`add authentication <authentication>`.
+a public page telling you to come back here and setup authentication.
+
+If this is the case - then you need to :ref:`add authentication <authentication>`.
+The installation will not move forward with without adding authentication.
+
+After adding authentication, but before actually testing that it works, you should
+:ref:`secure your apache <add-ssl>`. This way you never send credentials over plain http.
+
 You may also want to :ref:`enable SELinux <modify-system-security>`.
 
 If you're seeing the default apache page (Ubuntu users will) you will have to :ref:`debug virtualhosts <show-virtualhosts>`

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -143,22 +143,11 @@ Some operating systems use `Software Collections`_ to satisfy these.
 
 Now that Open OnDemand is installed and Apache is running, it should be serving
 a public page telling you to come back here and setup authentication.  If this
-is the case - you need to :ref:`add authentication <authentication>`.
-
-Before you actually use your credentials to login you should :ref:`secure your apache <add-ssl>`
-so that when you enter your credentials you send them over a secure channel.
-
-.. warning::
-
-   The installation will not move forward until you configure authentication. If
-   it continues to show the public page saying you need to configure authentication,
-   then you need to configure authentication for the installation to move forward.
-
+is the case - then you should :ref:`secure your apache <add-ssl>` then :ref:`add authentication <authentication>`.
 You may also want to :ref:`enable SELinux <modify-system-security>`.
 
 If you're seeing the default apache page (Ubuntu users will) you will have to :ref:`debug virtualhosts <show-virtualhosts>`
 and likely :ref:`configure a servername <ood-portal-generator-servername>`.
-
 
 Building From Source
 --------------------

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -143,7 +143,10 @@ Some operating systems use `Software Collections`_ to satisfy these.
 
 Now that Open OnDemand is installed and Apache is running, it should be serving
 a public page telling you to come back here and setup authentication.  If this
-is the case - then you should :ref:`secure your apache <add-ssl>` then :ref:`add authentication <authentication>`.
+is the case - you need to :ref:`add authentication <authentication>`.  Before you
+actually use your credentials to login you should :ref:`secure your apache <add-ssl>`
+so that when you enter your credentials you send them over a secure channel.
+
 You may also want to :ref:`enable SELinux <modify-system-security>`.
 
 If you're seeing the default apache page (Ubuntu users will) you will have to :ref:`debug virtualhosts <show-virtualhosts>`

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -143,14 +143,22 @@ Some operating systems use `Software Collections`_ to satisfy these.
 
 Now that Open OnDemand is installed and Apache is running, it should be serving
 a public page telling you to come back here and setup authentication.  If this
-is the case - you need to :ref:`add authentication <authentication>`.  Before you
-actually use your credentials to login you should :ref:`secure your apache <add-ssl>`
+is the case - you need to :ref:`add authentication <authentication>`.
+
+Before you actually use your credentials to login you should :ref:`secure your apache <add-ssl>`
 so that when you enter your credentials you send them over a secure channel.
+
+.. warning::
+
+   The installation will not move forward until you configure authentication. If
+   it continues to show the public page saying you need to configure authentication,
+   then you need to configure authentication for the installation to move forward.
 
 You may also want to :ref:`enable SELinux <modify-system-security>`.
 
 If you're seeing the default apache page (Ubuntu users will) you will have to :ref:`debug virtualhosts <show-virtualhosts>`
 and likely :ref:`configure a servername <ood-portal-generator-servername>`.
+
 
 Building From Source
 --------------------


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/ssl-install/

Reword this so that we reinforce that when it says you need to setup authentication - you really need to setup authentication. 
