### PR TITLE
add a warning about usernames & passwords

### DIFF
--- a/source/customizations/support-ticket.inc
+++ b/source/customizations/support-ticket.inc
@@ -44,6 +44,12 @@ These are the most common configuration properties needed to enable and setup th
 * ``delivery_settings``: Rails settings object to set the transport configuration properties.
   See example below or the `Rails documentation on mailers <https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration>`_.
 
+.. warning::
+
+  Use caution when supplying username and password in delivery_settings.  These files are readable by
+  unprivileged users and as such this information can be found by a sophsticated user without privilege
+  escelation.
+
 Sample configuration:
 
   .. code-block:: yaml


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/johrstrom-patch-2/

add a warning about supplying usernames & passwords in email support ticket configuration.
