### PR TITLE
add automation for syncing latest branch w development (#829)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Make Html
         run: |


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/BRANCH-NAME/

ports #829 to `latest` because this checkout v2 usesdeprecated things.
