### PR TITLE
Typo fixed

### DIFF
--- a/source/authentication.rst
+++ b/source/authentication.rst
@@ -11,7 +11,7 @@ focus on setting up some of the more common authentication modules (e.g.,
 OpenID Connect with KeyCloak).
 
 After installing Open OnDemand you **must** add authentiction of some kind
-to generate the correct apache configuration.  When no authentiction is
+to generate the correct Apache configuration.  When no authentiction is
 supplied Apache will only serve a static page that directs you here.
 
 No Open OnDemand functionality is available without authentiction.

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -145,14 +145,14 @@ Now that Open OnDemand is installed and Apache is running, it should be serving
 a public page telling you to come back here and setup authentication.
 
 If this is the case - then you need to :ref:`add authentication <authentication>`.
-The installation will not move forward with without adding authentication.
+The installation will not move forward without adding authentication.
 
 After adding authentication, but before actually testing that it works, you should
-:ref:`secure your apache <add-ssl>`. This way you never send credentials over plain http.
+:ref:`secure your Apache <add-ssl>`. This way you never send credentials over plain HTTP.
 
 You may also want to :ref:`enable SELinux <modify-system-security>`.
 
-If you're seeing the default apache page (Ubuntu users will) you will have to :ref:`debug virtualhosts <show-virtualhosts>`
+If you're seeing the default Apache page (Ubuntu users will) you will have to :ref:`debug virtualhosts <show-virtualhosts>`
 and likely :ref:`configure a servername <ood-portal-generator-servername>`.
 
 Building From Source


### PR DESCRIPTION
Fixed another minor typo for "Apache" and "apache" to maintain consistency in the guide.