### PR TITLE
Add login cluster only recipe

### DIFF
--- a/source/installation/cluster-config-schema.rst
+++ b/source/installation/cluster-config-schema.rst
@@ -190,3 +190,28 @@ See :ref:`Disable Host Link in Batch Connect Session Card <disable-host-link-bat
 .. note::
 
   The user is responsible for providing the `%s` that is used to place the script content. If a `script_wrapper` is provided without `%s` then batch connect applications are unlikely to work properly.
+
+
+******************
+Login Cluster Only
+******************
+
+Suppose you need want to create a *login cluster that does not schedule or run jobs*. It is used purely as a login/shell cluster only.
+
+To accomplish this, you need to simply leave out the ``v2job`` stanza that associates a scheduler with the cluster.
+
+An example config file in ``ondemand.d/pitzer_01_login.yml``:
+
+.. code-block:: yaml
+
+    ---
+    v2:
+    metadata:
+        title: "Pitzer Login"
+        url: "https://www.osc.edu/supercomputing/computing/pitzer"
+        hidden: false
+    login:
+        host: "pitzer-login01.hpc.osu.edu"
+
+Again, the thing to not here is we've left off the ``v2.job`` which renders the cluster useable only for logins, i.e.
+*no jobs will be scheduleable on this cluster.*

--- a/source/installation/cluster-config-schema.rst
+++ b/source/installation/cluster-config-schema.rst
@@ -213,5 +213,5 @@ An example config file in ``ondemand.d/pitzer_01_login.yml``:
     login:
         host: "pitzer-login01.hpc.osu.edu"
 
-Again, the thing to not here is we've left off the ``v2.job`` which renders the cluster useable only for logins, i.e.
+Again, the thing to note here is we've left off the ``v2.job`` which renders the cluster useable only for logins, i.e.
 *no jobs will be scheduleable on this cluster.*

--- a/source/installation/cluster-config-schema.rst
+++ b/source/installation/cluster-config-schema.rst
@@ -5,7 +5,6 @@ Cluster Config Schema v2
 
 The cluster config controls many OnDemand features including job submission, shell access, names in menus.
 
-*****************
 First an example:
 *****************
 
@@ -58,7 +57,6 @@ Below is the production configuration for OSC's Owens cluster.
 
 .. _the YAML spec: http://yaml.org/spec/1.2/spec.html#id2777534
 
-************
 A Break Down
 ************
 
@@ -191,8 +189,6 @@ See :ref:`Disable Host Link in Batch Connect Session Card <disable-host-link-bat
 
   The user is responsible for providing the `%s` that is used to place the script content. If a `script_wrapper` is provided without `%s` then batch connect applications are unlikely to work properly.
 
-
-******************
 Login Cluster Only
 ******************
 

--- a/source/installation/cluster-config-schema.rst
+++ b/source/installation/cluster-config-schema.rst
@@ -198,7 +198,7 @@ Login Cluster Only
 
 Suppose you need want to create a *login cluster that does not schedule or run jobs*. It is used purely as a login/shell cluster only.
 
-To accomplish this, you need to simply leave out the ``v2job`` stanza that associates a scheduler with the cluster.
+To accomplish this, you need to simply leave out the ``v2.job`` stanza that associates a scheduler with the cluster.
 
 An example config file in ``ondemand.d/pitzer_01_login.yml``:
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/login-cluster-only-recipe/

**Add your description here**
Adding section to cluster configuration to show users how to create a cluster config that is only used for logins and not to run jobs.