### PR TITLE
update auto_module docs based on feedback

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -218,7 +218,7 @@ auto_modules_<MODULE>
     The form configuration is case sensitive. So there is a difference between
     ``auto_modules_R`` and ``auto_modules_r``.
 
-    Also - hyphens cause issues in templating the script files. So, for example,
+    Hyphens cause issues in templating the script files. For example,
     a form configuration like ``auto_modules_netcdf-serial`` would need to be
     referenced in the ``script.sh.erb`` as ``<%= auto_modules_netcdf_serial %>``
     replacing any hyphens (``-``) with underscores ``_``.

--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -213,6 +213,17 @@ auto_modules_<MODULE>
   Meaning only versions appropriate to a given cluster will be shown when that
   cluster is chosen.
 
+  .. note::
+
+    The form configuration is case sensitive. So there is a difference between
+    ``auto_modules_R`` and ``auto_modules_r``.
+
+    Also - hyphens cause issues in templating the script files. So, for example,
+    a form configuration like ``auto_modules_netcdf-serial`` would need to be
+    referenced in the ``script.sh.erb`` as ``<%= auto_modules_netcdf_serial %>``
+    replacing any hyphens (``-``) with underscores ``_``.
+
+
 auto_groups
   This will automatically generate a ``select`` widget populated with a list of the Unix
   groups the user is currently in. Administrators can configure :ref:`filter for autogroups <auto_groups_filter>`

--- a/source/reference/files/ondemand-d-ymls.rst
+++ b/source/reference/files/ondemand-d-ymls.rst
@@ -595,7 +595,7 @@ Configuration Properties
   that there be a file for each cluster because the system can then tie those
   modules to that specific cluster.
   
-  This directory should have module spider-json output **for each cluster** 
+  This directory should have ``module spider-json`` output **for each cluster** 
   as indicated by the command below. Open OnDemand will read these files and
   potentially show them in a from for a cluster called **my_cluster**.
 

--- a/source/reference/files/ondemand-d-ymls.rst
+++ b/source/reference/files/ondemand-d-ymls.rst
@@ -591,9 +591,13 @@ Configuration Properties
 .. _module_file_dir:
 .. describe:: module_file_dir (String, null)
 
-  Specify a directory where module files per cluster exist. This directory
-  should have module spider-json output as indicated by the command below.
-  Open OnDemand will read these files and potentially show them in a from.
+  Specify a directory where **cluster specific module files** exist. It's important
+  that there be a file for each cluster because the system can then tie those
+  modules to that specific cluster.
+  
+  This directory should have module spider-json output **for each cluster** 
+  as indicated by the command below. Open OnDemand will read these files and
+  potentially show them in a from for a cluster called **my_cluster**.
 
   ``$LMOD_DIR/spider -o spider-json $MODULEPATH > /some/directory/my_cluster.json``
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/udpate-auto-modules/

Update the auto modules documentation based on feedback from this discourse topi - https://discourse.openondemand.org/t/auto-modules-module-name-label/3054/6 and this github issue - https://github.com/OSC/ondemand/issues/2933
