### PR TITLE
rename more to reference and remove ood in version policy

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -76,7 +76,7 @@ These are institutions who were early adopters or provided HPC resources for dev
 
 .. toctree::
   :maxdepth: 2
-  :caption: More
+  :caption: Reference
 
   architecture
   reference

--- a/source/version-policy.rst
+++ b/source/version-policy.rst
@@ -1,7 +1,7 @@
 .. _version_policy:
 
-OOD Versioning Policy
-===============================
+Versioning Policy
+=================
 
 This policy can be seen in the `Open OnDemand Versioning Policy document <https://github.com/OSC/ondemand/blob/master/VERSIONING_POLICY.md>`_ on GitHub.
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:
modifies `version-policy.rst` and `index.rst`.

https://osc.github.io/ood-documentation-test/more-to-reference/

This PR fixes 2 small things. First it changse More to Reference in the navigation section fixing #884 and also went ahead and remoed the OOD in the Versioning Policy header which had been asked but I forgot about.
