### PR TITLE
rm module enable for rhel9

### DIFF
--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -83,7 +83,6 @@ Some operating systems use `Software Collections`_ to satisfy these.
       .. code-block:: sh
 
          sudo dnf install epel-release
-         sudo dnf module enable ruby:3.0 nodejs:16
          sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
 
 2. Add repository and install


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/rhel9-deps/

Fixes #814  - though I don't know if it'll stay like this long term. We build against the default modules, so I'm guessing it'll last, but can't say that for sure. @treydock please advise.
