### PR TITLE
Removed instruction to install dnf modules for ruby and nodejs

### DIFF
--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -83,7 +83,6 @@ Some operating systems use `Software Collections`_ to satisfy these.
       .. code-block:: sh
 
          sudo dnf install epel-release
-         sudo dnf module enable ruby:3.0 nodejs:16
          sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
 
 2. Add repository and install


### PR DESCRIPTION
https://osc.github.io/ood-documentation/latest/installation/install-software.html

Enabling the dnf modules for ruby and nodejs is not required (and not working) on RHEL9. See also https://discourse.openondemand.org/t/ood3-installation-on-rhel9/2692