### PR TITLE
add docs on motd_render_html

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -74,7 +74,7 @@ To display a MOTD file on the Dashboard ensure that the environment variables ``
     The ``_erb`` formats support ERB rendering to generate more dynamic messages.
 
 .. warning::
-  Some MOTD formats like `rss`, `markdown` and `markdown_erb` can contain malicous
+  Some MOTD formats like ``rss``, ``markdown`` and ``markdown_erb`` can contain malicous
   HTML content. For your safety, by default, the Open OnDemand system will not render
   HTML.  We provide :ref:`a configuration to enable HTML rendering in MOTD <motd_render_html>`
   should you need to render HTML.

--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -73,6 +73,12 @@ To display a MOTD file on the Dashboard ensure that the environment variables ``
 .. tip::
     The ``_erb`` formats support ERB rendering to generate more dynamic messages.
 
+.. warning::
+  Some MOTD formats like `rss`, `markdown` and `markdown_erb` can contain malicous
+  HTML content. For your safety, by default, the Open OnDemand system will not render
+  HTML.  We provide :ref:`a configuration to enable HTML rendering in MOTD <motd_render_html>`
+  should you need to render HTML.
+
 .. figure:: /images/dashboard_motd.png
    :align: center
 

--- a/source/reference/files/ondemand-d-ymls.rst
+++ b/source/reference/files/ondemand-d-ymls.rst
@@ -846,3 +846,25 @@ Configuration Properties
     .. code-block:: yaml
 
       google_analytics_tag_id: 'abc123'
+
+
+.. _motd_render_html:
+.. describe:: motd_render_html (Boolean, false)
+
+  Render HTML in the Message of the Day (MOTD).  This
+  configuration was added because some MOTD formats like
+  RSS can generate HTML that is potentially unsafe.
+
+  Default
+    The Message of the day will not render HTML.
+
+    .. code-block:: yaml
+
+      motd_render_html: false
+
+  Example
+    The Message of the day will render HTML.
+
+    .. code-block:: yaml
+
+      motd_render_html: true


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/motd-render-html/

This adds docs on the `motd_render_html` configuration.
