### PR TITLE
fix authentication typos

### DIFF
--- a/source/authentication.rst
+++ b/source/authentication.rst
@@ -10,11 +10,11 @@ with an Open OnDemand installation. Tutorials will also be provided with the
 focus on setting up some of the more common authentication modules (e.g.,
 OpenID Connect with KeyCloak).
 
-After installing Open OnDemand you **must** add authentiction of some kind
-to generate the correct Apache configuration.  When no authentiction is
+After installing Open OnDemand you **must** add authentication of some kind
+to generate the correct Apache configuration.  When no authentication is
 supplied Apache will only serve a static page that directs you here.
 
-No Open OnDemand functionality is available without authentiction.
+No Open OnDemand functionality is available without authentication.
 
 .. note::
 

--- a/source/release-notes/v3.0-release-notes.rst
+++ b/source/release-notes/v3.0-release-notes.rst
@@ -257,7 +257,7 @@ Upgrade directions
       sudo yum clean all
       sudo yum update ondemand
 
-#. (Optional) If using Dex based authentiction, update the ``ondemand-dex`` package.
+#. (Optional) If using Dex based authentication, update the ``ondemand-dex`` package.
 
    .. code-block:: sh
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://github.com/OSC/ood-documentation/blob/develop/source/authentication.rst

**Add your description here**
Fixes "authentication" typos -- was "authentiction"

Supersedes https://github.com/OSC/ood-documentation/pull/917