### PR TITLE
kilobyte -> kibibyte

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -899,7 +899,7 @@ resources used by the user alone. This is the default type of quota object and
 is given in the following format:
 
 
-.. warning:: A block must be equal to 1 KB for proper conversions.
+.. warning:: A block must be equal to 1 KiB for proper conversions.
 
 
 Individual Fileset Quota


### PR DESCRIPTION
while configuring quota warnings, I converted to "blocks" by dividing "number of bytes" by 1000, because it said `KB`. But in the source code, it's using 1024.

https://github.com/OSC/ondemand/blob/5ae612e418d5be1654d663a7edd8da29d66d9b70/apps/dashboard/app/models/quota.rb#L7