### PR TITLE
Add information about ProxyTimeout

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -1325,3 +1325,17 @@ For completed sessions, the system will only show the delete button.
 
 .. _OSC's rclone documentation: https://www.osc.edu/resources/getting_started/howto/howto_use_rclone_to_upload_data
 .. _2.0 documentation for controling the navbar: https://osc.github.io/ood-documentation/release-2.0/customization.html#control-which-apps-appear-in-the-dashboard-navbar
+
+Preventing VNC from timing out when inactive
+--------------------------------------------
+
+After a configurable period, the Apache reverse proxy will time out connections. This can cause the in-browser noVNC client to lose contact with running sessions, since the websocket will close.
+To prevent this, you can simply reconfigure the mod_proxy `ProxyTimeout` parameter (or, if you wish, the Apache `Timeout` parameter, which is what `ProxyTimeout` will be set to by default.
+
+Create a new .conf file in Apache's conf.d setting the value, for example:
+
+```
+echo "ProxyTimeout 3600" > /etc/httpd/conf.d/proxytimeout.conf
+```
+
+This will set the timeout to 1 hour, instead of the default 1 minute.


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/BRANCH-NAME/

**Add your description here**

The websockify connection will occasionally drop when the VNC session sits idle for a while, producing messages in vnc.log like this: 

`Client 127.0.0.1 gone`

To reconnect, the user cannot press the noVNC button, but has to go back to OOD and click the card button since. In order to avoid this, a simple fix is just increasing the timeout that mod_proxy uses.

It might be worth setting this value by means of the portal config generator, but for now I just made this PR to the docs so that others don't need to spend as much time as I did chasing the cause of this issue.
