### PR TITLE
Update customizations.rst illegal characters in OOD_JOB_NAME_ILLEGAL_…

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -1159,7 +1159,7 @@ To resolve this set ``OOD_JOB_NAME_ILLEGAL_CHARS`` to ``/`` for all OOD applicat
 
   # /etc/ood/config/nginx_stage.yml
   pun_custom_env:
-    - OOD_JOB_NAME_ILLEGAL_CHARS: "/"
+    OOD_JOB_NAME_ILLEGAL_CHARS: "/"
 
 .. _customize_dex_theme:
 


### PR DESCRIPTION
…CHARS example

Cut and paste of the example for OOD_JOB_NAME_ILLEGAL_CHARS resulted in an error.  Removing the hyphen at the start of the line fixed this.  Original page seen here https://osc.github.io/ood-documentation/latest/customizations.html#set-illegal-job-name-characters

**Modify this link to include the branch name, and possibly the page this PR modifies**:
https://github.com/OSC/ood-documentation/blob/latest/source/customizations.rst
**Add your description here**
