### PR TITLE
fix typo around centos 7 support

### DIFF
--- a/source/release-notes/v3.1-release-notes.rst
+++ b/source/release-notes/v3.1-release-notes.rst
@@ -54,7 +54,9 @@ Deprecations
 RedHat/CentOS 7 packages deprecated
 ***********************************
 
-OnDemand 3.1 will be the last OnDemand release to support RedHat/CentOS 7.
+OnDemand 3.0 was the last OnDemand release to support RedHat/CentOS 7.
+
+3.1 does not support RedHat/CentOS 7.
 
 Dependency updates
 ..................


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/fix-el7-typo-rns/

**Add your description here**
Fix typo around CentOS 7 support for `3.1`.