### PR TITLE
Adds instruction for auto_ form attributes

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -200,10 +200,10 @@ They must be added to the `form` list.
 
 EX:
 
-```
-form:
-  - auto_modules_<MODULE>
-```
+.. code-block:: yaml
+
+  form:
+    - auto_modules_<MODULE>
 
 auto_primary_group
   This will automatically set the `OodCore::Job::Script#accounting_id`_ to the

--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -196,6 +196,15 @@ input the queue name themselves.
 for the user to choose from without intervention from the administrator
 or the user.
 
+They must be added to the `form` list.
+
+EX:
+
+```
+form:
+  - auto_modules_<MODULE>
+```
+
 auto_primary_group
   This will automatically set the `OodCore::Job::Script#accounting_id`_ to the
   primary group of the user.  No choice will be given to the user.


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/update-auto-attributes-doc

Modifies:
https://osc.github.io/ood-documentation/latest/how-tos/app-development/interactive/form.html#automatic-predefined-attributes

**Add your description here**
Based on confusion surrounding the fact that `auto_` form attributes need to be added to the `form` list in `form.yml`