### PR TITLE
correct default bc_dynamic_js

### DIFF
--- a/source/reference/files/ondemand-d-ymls.rst
+++ b/source/reference/files/ondemand-d-ymls.rst
@@ -498,7 +498,7 @@ Configuration Properties
 
     .. code-block:: yaml
 
-      bc_dynamic_js: true
+      bc_dynamic_js: false
 
   Example
     Interactive app forms will be dynamic.


### PR DESCRIPTION
correct default bc_dynamic_js because it's false (disabled) by default.

**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/johrstrom-patch-1/

correct default bc_dynamic_js because it's false (disabled) by default.
