### PR TITLE
Misc updates

### DIFF
--- a/source/how-tos/app-development/interactive/template.rst
+++ b/source/how-tos/app-development/interactive/template.rst
@@ -160,15 +160,16 @@ but not limited to:
 There exists some helpful Bash functions that can be used in this sourced
 script:
 
-.. describe:: find_port [MIN_PORT] [MAX_PORT]
+.. describe:: find_port [HOSTNAME] [MIN_PORT] [MAX_PORT]
 
-   Finds an available port within the specified range [MIN_PORT..MAX_PORT].
+   Finds an available port within the specified range [MIN_PORT..MAX_PORT]
+   on the [HOSTNAME].
 
    Default
-     [2000..65535]
+      localhost 2000 65535
 
    Example
-     Find a random port that is available within the default range
+     Find a random port that is available within the default range on the ``localhost``.
 
      .. code-block:: sh
 

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -121,8 +121,8 @@ Some operating systems use `Software Collections`_ to satisfy these.
          .. code-block:: sh
 
             sudo apt install apt-transport-https ca-certificates
-            wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.0-focal_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.0-focal_all.deb
-            sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.0-focal_all.deb
+            wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.1-focal_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.1-focal_all.deb
+            sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.1-focal_all.deb
             sudo apt update
 
             sudo apt install ondemand
@@ -132,8 +132,8 @@ Some operating systems use `Software Collections`_ to satisfy these.
          .. code-block:: sh
 
             sudo apt install apt-transport-https ca-certificates
-            wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.0-jammy_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.0-jammy_all.deb
-            sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.0-jammy_all.deb
+            wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.1-jammy_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.1-jammy_all.deb
+            sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.1-jammy_all.deb
             sudo apt update
 
             sudo apt install ondemand
@@ -143,8 +143,8 @@ Some operating systems use `Software Collections`_ to satisfy these.
          .. code-block:: sh
 
             sudo apt install apt-transport-https ca-certificates
-            wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.0-bookworm_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.0-bookworm_all.deb
-            sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.0-bookworm_all.deb
+            wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.1-bookworm_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.1-bookworm_all.deb
+            sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.1-bookworm_all.deb
             sudo apt update
 
             sudo apt install ondemand

--- a/source/reference/files/submit-yml/vnc-container-bc-options.rst
+++ b/source/reference/files/submit-yml/vnc-container-bc-options.rst
@@ -15,6 +15,7 @@ All the options in :ref:`vnc-bc-options` apply in addition to what's listed belo
       container_bindpath: ""
       container_module: "singularity"
       container_command: "singularity"
+      container_start_args: []
 
 
 .. describe:: container_path (String, "vnc_container.sif")
@@ -89,6 +90,24 @@ All the options in :ref:`vnc-bc-options` apply in addition to what's listed belo
 
         container_module: "apptainer"
 
+.. describe:: container_start_args (String, [])
+
+    Arguments to pass to the container start command.
+
+    Default
+      Pass no additional arguments.
+
+      .. code-block:: yaml
+
+        container_start_args: []
+
+    Example
+      Pass ``--fakeroot`` to the container ``start`` command.
+
+      .. code-block:: yaml
+
+        container_start_args:
+          - "--fakeroot"
 
 Starter def file
 ................


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/misc-updates/

These are some miscellaneous updates. First updating vnc_container for missing 3.1 option.
The second 

fixes #945.
fixes #944 
