### PR TITLE
add favorites to the path_selector

### DIFF
--- a/source/how-tos/app-development/interactive/form-widgets.rst
+++ b/source/how-tos/app-development/interactive/form-widgets.rst
@@ -143,6 +143,9 @@ Form Widgets
     ``show_files`` is a boolean flag to show files or not. This defaults
     to true - it will show files.
 
+    ``favorites`` allows you to override the :ref:`favorite paths you've added
+    in files menu <add-shortcuts-to-files-menu>`.
+
       .. code-block:: yaml
 
         path:
@@ -150,6 +153,9 @@ Form Widgets
           directory: "/fs/ess/project"
           show_hidden: true
           show_files: false
+          favorites:
+            - /fs/ess
+            - /fs/scratch
 
 ==================================================================
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/path-selector-favs/

This adds docs for overriding the `favorite_paths` for the path selector. @Oglopf this may help with your confusion in https://github.com/OSC/ondemand/pull/3420
