### PR TITLE
Remove outdated warning banner in linux host adapter

### DIFF
--- a/source/installation/resource-manager/linuxhost.rst
+++ b/source/installation/resource-manager/linuxhost.rst
@@ -3,8 +3,6 @@
 LinuxHost
 =========
 
-.. warning:: While we have tested this at OSC, we do not currently use it in a production capacity nor do any other centers as of April 23, 2020. If you are an early adopter of this feature, please let us know on Discourse or by email about your experience and any improvements we can make.
-
 The LinuxHost adapter facilitates launching jobs immediately without using a batch scheduler or resource manager. Use cases for this non-traditional job adapter include:
 
 - Interactive work on login nodes, such as remote desktop or IDE


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/linux-host-remove-warning/

**Add your description here**
Remove warning banner for linux host adapter as it is no longer needed.