### PR TITLE
remove el7 from install page.

### DIFF
--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -56,19 +56,6 @@ Some operating systems use `Software Collections`_ to satisfy these.
          sudo dnf install epel-release
          sudo dnf module enable ruby:3.1 nodejs:18
 
-   .. tab:: RHEL 7
-
-      .. warning::
-
-         You may also need to enable the *Optional* channel and
-         attach a subscription providing access to RHSCL to be able to use this
-         repository.
-
-      .. code-block:: sh
-
-         sudo yum install epel-release
-         sudo subscription-manager repos --enable=rhel-server-rhscl-7-rpms
-
 
    .. tab:: RHEL 8
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/BRANCH-NAME/

Remove el7 from the install page because el7 is not supported in the current version.
