### PR TITLE
Spell remotes properly

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -1300,7 +1300,7 @@ Accessing Remote File Systems
 
 Since 2.1 you can use ``rclone`` to interact with remote file systems.  Since
 every command in Open OnDemand is issued *as the user*, the user themselves
-are required to setup their ``rclone`` remomtes.
+are required to setup their ``rclone`` remotes.
 
 You can refer to the `OSC's rclone documentation`_ on how to configure rclone
 remotes.


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/karcaw-patch-1/

**Add your description here**
Found a spelling error..  Fixed it.