### PR TITLE
fix this example

### DIFF
--- a/source/reference/files/nginx-stage-yml.rst
+++ b/source/reference/files/nginx-stage-yml.rst
@@ -123,14 +123,14 @@ Configuration Options
 
     .. code-block:: yaml
 
-      pun_custom_env: {}
+      pun_custom_env_declarations: []
 
   Example
     Decleary several environment variables to pass to the PUN.
 
     .. code-block:: yaml
 
-      pun_custom_env:
+      pun_custom_env_declarations:
         - PATH
         - LD_LIBRARY_PATH
         - MANPATH


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/nginx-bug-fix/

This fixes an nginx_stage example that has the wrong key in it.
