### PR TITLE
Adds line about filtering auto_modules to docs

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -228,12 +228,15 @@ auto_modules_<MODULE>
 
   Regex:
   .. code-block:: yaml
+
     attributes:
       auto_modules_matlab:
         filter: (intel|gnu)\d*
 
   String:
+
   .. code-block:: yaml
+    
     attributes:
       auto_modules_matlab:
         filter: intel

--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -222,6 +222,21 @@ auto_modules_<MODULE>
      attributes:
        auto_modules_matlab:
          default: false
+
+  To filter versions that show up in the drop-down list, you can use a Ruby regex (https://rubular.com/)
+  (without the wrapping `//`) or a string:
+
+  Regex:
+  .. code-block:: yaml
+    attributes:
+      auto_modules_matlab:
+        filter: (intel|gnu)\d*
+
+  String:
+  .. code-block:: yaml
+    attributes:
+      auto_modules_matlab:
+        filter: intel
   
   See :ref:`the module directory configuration <module_file_dir>` on how to enable
   the cluster module files that need to be read.

--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -227,6 +227,7 @@ auto_modules_<MODULE>
   (without the wrapping `//`) or a string:
 
   Regex:
+
   .. code-block:: yaml
 
     attributes:


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/auto-modules-filtering/

https://osc.github.io/ood-documentation/latest/how-tos/app-development/interactive/form.html#auto-bc-form-options

**Add your description here**
