### PR TITLE
Update advanced-configs.rst to fix a typo

### DIFF
--- a/source/installation/resource-manager/advanced-configs.rst
+++ b/source/installation/resource-manager/advanced-configs.rst
@@ -1,6 +1,6 @@
 .. _advanced-resource-manager-configs:
 
-Advanced Resource Manager Configrations
+Advanced Resource Manager Configurations
 =======================================
 
 This page details advanced settings for any resource manager


### PR DESCRIPTION
minor typo 'configrations'


Just added the missing letter in 'configrations' to make it 'configurations'
