### PR TITLE
Update debugging apache2 Ubuntu session

### DIFF
--- a/source/authentication/overview/map-user.rst
+++ b/source/authentication/overview/map-user.rst
@@ -23,7 +23,7 @@ Both with variations will be discussed here.
 Remote User
 -----------
 
-It's worth discussusing where ``REMOTE_USER`` is comfing from.  When apache
+It's worth discussusing where ``REMOTE_USER`` is coming from.  When apache
 has successfully authenticates a request it sets the variable ``REMOTE_USER``
 from, well, the remote.
 

--- a/source/how-tos/debug/debug-apache.rst
+++ b/source/how-tos/debug/debug-apache.rst
@@ -77,7 +77,7 @@ Or you're using the wrong hostname in your browser.
 
          .. code-block:: sh
 
-          sudo /sbin/apache2 -S
+          . /etc/apache2/envvars; sudo -E /sbin/apache2 -S
 
 Performance Tuning
 ------------------


### PR DESCRIPTION
In order to get a proper response when printing the apache's virtualhosts on a ubuntu host, one needs to define the environment variables. 

If one executes the command as stated in the documentation the following error may occur:

```
sudo /sbin/apache2 -S

[Thu Jul 11 19:19:47.737120 2024] [core:warn] [pid 8874] AH00111: Config variable ${APACHE_RUN_DIR} is not defined
apache2: Syntax error on line 80 of /etc/apache2/apache2.conf: DefaultRuntimeDir must be a valid directory, absolute or relative to ServerRoot
```

Changing to proposed by this PR
```
. /etc/apache2/envvars ; sudo -E apache2 -S

AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using fec0::5055:55ff:feba:170c. Set the 'ServerName' directive globally to suppress this message
VirtualHost configuration:
*:8080                 localhost (/etc/apache2/sites-enabled/ood-portal.conf:45)
ServerRoot: "/etc/apache2"
Main DocumentRoot: "/var/www/html"
Main ErrorLog: "/var/log/apache2/error.log"
Mutex watchdog-callback: using_defaults
Mutex rewrite-map: using_defaults
Mutex lua-ivm-shm: using_defaults
Mutex proxy: using_defaults
Mutex default: dir="/var/run/apache2/" mechanism=default 
PidFile: "/var/run/apache2/apache2.pid"
Define: DUMP_VHOSTS
Define: DUMP_RUN_CFG
User: name="www-data" id=33
Group: name="www-data" id=33
```

In addition, this pr fixes a small typo that I noted. 
