### PR TITLE
add info about disabling apps to customizations

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -7,6 +7,37 @@ Customizations
   Check out the :ref:`pun-environment` for an overview of how environment variables can be
   added.
 
+.. _disabling_applications:
+
+Disabling applications
+----------------------
+
+OnDemand is comprised of a few components. Each of which you can disable or limit
+access by simply changing the file permissions of the application.
+
+All the applications OnDemand installs are located in `/var/www/ood/apps/sys`.
+So, for example, if you wished to disable the file browser you would simply
+change it's directory to 700 so it's unreadable by regular users.
+
+When this directory is unreadable by regular users, the functionality
+it provides will be disabeled.
+
+.. code-block:: sh
+
+  sudo chmod 700 /var/www/ood/apps/sys/files
+
+Alternatively, if you wished to limit acess you can do so through group
+permissions. For example, if you wanted to limit access to the file browser
+to only memebers in the Unix group ``staff``, you would simply apply the
+applicable file permission such that anonymous users cannot access the
+directory while members of the ``staff`` Unix group can.
+
+.. code-block:: sh
+
+  sudo chmod 750 /var/www/ood/apps/sys/files
+  sudo chown root:staff /var/www/ood/apps/sys/files
+
+
 Announcements
 -------------
 

--- a/source/security.rst
+++ b/source/security.rst
@@ -32,7 +32,8 @@ that some centers may want to change or disable altogether.
 - **File Access**: OnDemand lets users navigate the file system. While file permissions
   limit what a user can view and navigate to, some centers may want to limit this even further.
   One option is to :ref:`set-file-allowlist` to limit what directories users may navigate to.
-
+  Additionally, you may want to disable or limit access to the application. You can do this
+  through :ref:`disabling_applications`.
 
 Additional Information
 ----------------------


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/disable-apps/

This adds information about how to disable or limit apps in the customization section. I see now that this is a bit duplicate of what's in app sharing, but I feel like it's more discoverable here. Plus a much more common use case as few sites enable app sharing and never even navigate to that page.
