### PR TITLE
Remove references to EL7

### DIFF
--- a/source/authentication/oidc.rst
+++ b/source/authentication/oidc.rst
@@ -12,7 +12,7 @@ The following prerequisites need to be satisfied:
 
 .. note::
 
-   OnDemand repos provide the ``httpd24-mod_auth_openidc`` RPM for RHEL 7 and CentOS 7 as it must be built against SCL Apache. The OnDemand repos also have the ``mod_auth_openidc`` RPM for RHEL 8 and Rocky 8 that are newer than what the OS provides to make use of some newer features.
+   The OnDemand repos have the ``mod_auth_openidc`` RPM for RHEL 8 and Rocky 8 that are newer than what the OS provides to make use of some newer features.
 
 The following is an example :program:`ood-portal-generator` configuration file:
 

--- a/source/how-tos/debug/debug-apache.rst
+++ b/source/how-tos/debug/debug-apache.rst
@@ -23,13 +23,6 @@ Restart services
 
    .. tabs::
 
-      .. tab:: RHEL/CentOS 7
-
-        .. code-block:: sh
-
-          sudo systemctl try-restart httpd24-httpd
-
-
       .. tab:: RHEL/Rocky 8 & 9
 
          .. code-block:: sh
@@ -60,12 +53,6 @@ which corresponds directly to `Apache's ServerName configuration`_ (and restart 
 Or you're using the wrong hostname in your browser.
 
    .. tabs::
-
-      .. tab:: RHEL/CentOS 7
-
-        .. code-block:: sh
-
-          sudo /opt/rh/httpd24/root/sbin/httpd -S
 
       .. tab:: RHEL/Rocky 8 & 9
 

--- a/source/how-tos/monitoring/prometheus.rst
+++ b/source/how-tos/monitoring/prometheus.rst
@@ -33,19 +33,12 @@ For yum/dnf based systems the `ondemand_exporter`_ can be installed via RPM.
 
 The RPM will install the following files that should work out of the box:
 
-- **RHEL/CentOS 7 only**: /opt/rh/httpd24/root/etc/httpd/conf.d/ondemand_exporter.conf
 - **RHEL/Rocky/AlmaLinux 8 & 9 only**: /etc/httpd/conf.d/ondemand_exporter.conf
 - /etc/sudoers.d/ondemand_exporter
 
 Ensure that the new Apache configuration is loaded by restarting Apache
 
 .. tabs::
-
-   .. tab:: RHEL/CentOS 7
-
-      .. code-block:: sh
-
-         sudo systemctl restart httpd24-httpd
 
    .. tab:: RHEL/Rocky/Alma Linux 8 & 9
 
@@ -81,13 +74,6 @@ Check for the `ondemand_exporter Latest Release`_ version number.  Replace ``VER
    sudo systemctl daemon-reload
 
 .. tabs::
-
-   .. tab:: RHEL/CentOS 7
-
-      .. code-block:: sh
-
-         sudo install -o root -g root -m 0440 /tmp/${ARCHIVE}/files/apache.conf /opt/rh/httpd24/root/etc/httpd/conf.d/ondemand_exporter.conf
-         sudo systemctl restart httpd24-httpd
 
    .. tab:: RHEL/Rocky/Alma Linux 8 & 9
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -6,7 +6,7 @@ Installation
 The OnDemand host machine needs to be setup *similarly* to a login node. This
 means that it will need:
 
-- RedHat/CentOS 7+ or Ubuntu 20.04-22.04 or Debian 12 or Amazon Linux 2023
+- RedHat/RockyLinux/AlmaLinux 8+ or Ubuntu 20.04-22.04 or Debian 12 or Amazon Linux 2023
 - the resource manager (e.g., Torque, Slurm, or LSF) client binaries and
   libraries used by the batch servers installed
 - configuration on both OnDemand node **and batch servers** to be able to

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -33,13 +33,6 @@ Some operating systems use `Software Collections`_ to satisfy these.
 
 .. tabs::
 
-   .. tab:: CentOS 7
-
-      .. code-block:: sh
-
-         sudo yum install centos-release-scl epel-release
-
-
    .. tab:: RockyLinux/Alma Linux 8
 
       .. code-block:: sh
@@ -78,14 +71,6 @@ Some operating systems use `Software Collections`_ to satisfy these.
 -----------------------------
 
    .. tabs::
-
-      .. tab:: RedHat/CentOS 7
-
-         .. code-block:: sh
-
-            sudo yum install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-1.el7.noarch.rpm
-
-            sudo yum install ondemand
 
       .. tab:: RedHat/Rocky Linux/AlmaLinux 8
 
@@ -148,14 +133,6 @@ Some operating systems use `Software Collections`_ to satisfy these.
 -----------------
 
    .. tabs::
-
-      .. tab:: RHEL/CentOS 7
-
-        .. code-block:: sh
-
-          sudo systemctl start httpd24-httpd
-          sudo systemctl enable httpd24-httpd
-
 
       .. tab:: RHEL/Rocky 8 & 9
 

--- a/source/installation/resource-manager/test.rst
+++ b/source/installation/resource-manager/test.rst
@@ -22,18 +22,6 @@ configuration files.
 
 #. We will now list all available tasks that we can run:
 
-   .. rubric:: If your operating system is CentOS 7 or RHEL 7, run this command:
-
-   .. code-block:: sh
-
-      scl enable ondemand -- bin/rake -T test:jobs
-      # rake test:jobs           # Test all clusters
-      # rake test:jobs:cluster1  # Test the cluster: cluster1
-      # rake test:jobs:cluster2  # Test the cluster: cluster2
-
-
-   .. rubric:: Otherwise, run this command:
-
    .. code-block:: sh
 
       source /opt/ood/ondemand/enable

--- a/source/reference/files/nginx-stage-yml.rst
+++ b/source/reference/files/nginx-stage-yml.rst
@@ -788,15 +788,11 @@ Configuration Options
         min_uid: 1000
 
    Example
-     Using CentOS 6
+     Define new minimum UID
 
      .. code-block:: yaml
 
         min_uid: 500
-
-   .. note::
-
-      For RHEL6 and CentOS 6 the user id's begin at ``500``.
 
 .. _disabled_shell:
 

--- a/source/reference/files/submit-yml/basic-bc-options.rst
+++ b/source/reference/files/submit-yml/basic-bc-options.rst
@@ -235,7 +235,7 @@ Basic Batch Connect Options
           # careful now, we can't override run_file or we have to
           # change it here too!  This also doesn't account for timeout,
           # if it's provided.
-          IMAGE=/opt/images/centos7.sif
+          IMAGE=/opt/images/el9.sif
           singularity exec -p $IMAGE /bin/bash script.sh
 
 .. describe:: script_file (String, "./script.sh")

--- a/source/requirements.rst
+++ b/source/requirements.rst
@@ -17,7 +17,6 @@ At this time OnDemand only supports the following operating systems and architec
    :header: "","x86_64","aarch64/arm64","ppc64le"
    :stub-columns: 1
 
-   "RedHat/CentOS 7",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#9989;`
    "RedHat/Rocky Linux/AlmaLinux 8",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#9989;`
    "RedHat/Rocky Linux/AlmaLinux 9",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#9989;`
    "Ubuntu 20.04",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#10060;`


### PR DESCRIPTION
EL7 is now EOL and not supported by upstream vendors or OnDemand

**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/rm-el7/

**Add your description here**
