### PR TITLE
Start 4.0 release notes

### DIFF
--- a/source/release-notes.rst
+++ b/source/release-notes.rst
@@ -6,6 +6,7 @@ Release Notes
 .. toctree::
    :maxdepth: 2
 
+   release-notes/v4.0-release-notes
    release-notes/v3.1-release-notes
    release-notes/v3.0-release-notes
    release-notes/v2.0-release-notes

--- a/source/release-notes/allowlist.inc
+++ b/source/release-notes/allowlist.inc
@@ -1,0 +1,12 @@
+These configurations that have whitelist in the name have been deprecated
+in 3.0 and replaced with allowlist or blocklist in 4.0.
+
+The configurations ``maintenance_ip_whitelist`` for configuring maintenance ips
+has been replaced by ``maintenance_ip_allowlist``.
+
+The ``WHITELIST_PATH`` environment variable for configuring inaccessible paths
+in the file browser has been replaced by ``OOD_ALLOWLIST_PATH``.
+
+ACL configurations in ``cluster.d`` files now use  ``allowlist`` and ``blocklist``
+instead of ``whitelist`` and ``blacklist``, though sites should just use
+Linux FACLs to control these files instead of these configurations.

--- a/source/release-notes/autoload.inc
+++ b/source/release-notes/autoload.inc
@@ -1,0 +1,28 @@
+This comes from the Ruby on Rails framework that Open OnDemand utilizes.
+It affects initializers you may have written, for example to :ref:`add-shortcuts-to-files-menu`.
+
+To resolve this, wrap your code in a  ``Rails.application.config.after_initialize`` block.
+
+For example, if you have:
+
+.. code-block:: ruby
+
+  # /etc/ood/config/apps/dashboard/initializers/ood.rb
+
+    OodFilesApp.candidate_favorite_paths.tap do |paths|
+      # add User project space directory
+      paths << FavoritePath.new("/fs/project/#{User.new.name}")
+    end
+
+You will need to modify that file like so:
+
+.. code-block:: ruby
+
+  # /etc/ood/config/apps/dashboard/initializers/ood.rb
+
+    Rails.application.config.after_initialize do
+      OodFilesApp.candidate_favorite_paths.tap do |paths|
+        # add User project space directory
+        paths << FavoritePath.new("/fs/project/#{User.new.name}")
+      end
+    end

--- a/source/release-notes/navconfig.inc
+++ b/source/release-notes/navconfig.inc
@@ -1,0 +1,7 @@
+The initializers used to modify the navigation bar and the class
+``NavConfig`` is deprecated in 3.0 and will be removed in 4.0.
+The 3.x series will continue to support this, but sites should use the
+``nav_categories`` property instead.
+
+See :ref:`limit-auto-generated-menu-bars` and the
+:ref:`nav_categories configuration property <nav_categories>` for more details.

--- a/source/release-notes/v3.0-release-notes.rst
+++ b/source/release-notes/v3.0-release-notes.rst
@@ -110,60 +110,17 @@ Deprecations
 Autoloading during initialization is deprecated.
 ************************************************
 
-This comes from the Ruby on Rails framework that Open OnDemand utilizes.
-It affects initializers you may have written, for example to :ref:`add-shortcuts-to-files-menu`.
-
-To resolve this, wrap your code in a  ``Rails.application.config.after_initialize`` block.
-
-For example, if you have:
-
-.. code-block:: ruby
-
-  # /etc/ood/config/apps/dashboard/initializers/ood.rb
-
-    OodFilesApp.candidate_favorite_paths.tap do |paths|
-      # add User project space directory
-      paths << FavoritePath.new("/fs/project/#{User.new.name}")
-    end
-
-You will need to modify that file like so:
-
-.. code-block:: ruby
-
-  # /etc/ood/config/apps/dashboard/initializers/ood.rb
-
-    Rails.application.config.after_initialize do
-      OodFilesApp.candidate_favorite_paths.tap do |paths|
-        # add User project space directory
-        paths << FavoritePath.new("/fs/project/#{User.new.name}")
-      end
-    end
+.. include:: autoload.inc
 
 NavConfig is deprecated
 ***********************
 
-The initializers used to modify the navigation bar and the class
-``NavConfig`` is deprecated.  The 2.x series will continue to support
-this, but sites should use the ``nav_categories`` property instead.
-
-See :ref:`limit-auto-generated-menu-bars` and the
-:ref:`nav_categories configuration property <nav_categories>` for more details.
+.. include:: navconfig.inc
 
 whitelist & blacklist configs are deprecated
 ********************************************
 
-These configurations that have whitelist in the name have been deprecated
-and replaced with allowlist or blocklist.
-
-The configurations ``maintenance_ip_whitelist`` for configuring maintenance ips
-has been replaced by ``maintenance_ip_allowlist``.
-
-The ``WHITELIST_PATH`` environment variable for configuring inaccessible paths
-in the file browser has been replaced by ``OOD_ALLOWLIST_PATH``.
-
-ACL configurations in ``cluster.d`` files now use  ``allowlist`` and ``blocklist``
-instead of ``whitelist`` and ``blacklist``, though sites should just use
-Linux FACLs to control these files instead of these configurations.
+.. include:: allowlist.inc
 
 Dependency updates
 ..................

--- a/source/release-notes/v4.0-release-notes.rst
+++ b/source/release-notes/v4.0-release-notes.rst
@@ -1,0 +1,58 @@
+.. _v4.0-release-notes:
+
+v4.0 Release Notes
+==================
+
+Administrative changes
+----------------------
+
+- `Breaking Changes`_
+
+New Features
+------------
+
+Thanks!
+-------
+
+We'd like to thank a bunch of folks' for contributing to this release.
+As we only know the github username, that's what's being referenced here.
+
+
+
+Details of administrative changes
+---------------------------------
+
+Breaking Changes
+................
+
+Autoloading during initialization has been removed.
+***************************************************
+
+.. include:: autoload.inc
+
+NavConfig has been removed.
+***************************
+
+.. include:: navconfig.inc
+
+whitelist & blacklist configs have been removed.
+************************************************
+
+.. include:: allowlist.inc
+
+Dependency updates
+..................
+
+
+
+SELinux changes
+...............
+
+
+Upgrade directions
+..................
+
+
+
+Details of new features
+-----------------------


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/start-4.0/

This just starts the 4.0 release notes.