### PR TITLE
fix typo is link as well

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -1478,4 +1478,4 @@ For completed sessions, the system will only show the delete button.
 .. include:: customizations/support-ticket.inc
 
 .. _OSC's rclone documentation: https://www.osc.edu/resources/getting_started/howto/howto_use_rclone_to_upload_data
-.. _2.0 documentation for controling the navbar: https://osc.github.io/ood-documentation/release-2.0/customization.html#control-which-apps-appear-in-the-dashboard-navbar
+.. _2.0 documentation for controlling the navbar: https://osc.github.io/ood-documentation/release-2.0/customization.html#control-which-apps-appear-in-the-dashboard-navbar


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/fix-latest/

The last merge updated the typo in this link, but didn't update the link itself.
