### PR TITLE
add docs on dismisable/required announcements

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -64,7 +64,7 @@ the user would see this message at the top of the dashboard:
 
 If the announcement file has the extension ``yml`` and is a yaml file it is first rendered using ERB and then the resulting file is parsed as YAML. The valid keys are:
 
-.. list-table:: Config Files
+.. list-table:: Announcement configuration keys.
 
    * - Key
      - Description

--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -38,6 +38,8 @@ directory while members of the ``staff`` Unix group can.
   sudo chown root:staff /var/www/ood/apps/sys/files
 
 
+.. _configure_announcements:
+
 Announcements
 -------------
 
@@ -63,14 +65,24 @@ the user would see this message at the top of the dashboard:
 If the announcement file has the extension ``yml`` and is a yaml file it is first rendered using ERB and then the resulting file is parsed as YAML. The valid keys are:
 
 .. list-table:: Config Files
-   :stub-columns: 1
 
+   * - Key
+     - Description
    * - type
-     - warning, info, success, or danger
-     - this is the Bootstrap alert style
+     - The type of announcment. Values can be ``warning``, ``info``, ``success``, or ``danger``.
    * - msg
-     - string containing markdown formatted message
-     - if this is a blank string (only whitespace), the alert will not display
+     - The announcement's message.
+   * - dismissable
+     - Specify if the announcment is dismissable or not with ``true`` or ``false``.
+       Defaults to ``true``.
+   * - required
+     - Specify if the announcment is required or not with ``true`` or ``false``.
+       Defaults to ``false``. When this is set to ``true``, the user will not be
+       do anything until the announcment has been accepted.
+
+.. tip::
+  You can use ``required`` announcements to present users with a ToS (terms of service),
+  EULA (end user license agreement) or similar.
 
 Because the announcement is rendered via ERB you can do some interesting things, like stop showing the announcement past a specified date:
 

--- a/source/release-notes/v4.0-release-notes.rst
+++ b/source/release-notes/v4.0-release-notes.rst
@@ -40,6 +40,19 @@ whitelist & blacklist configs have been removed.
 
 .. include:: allowlist.inc
 
+Announcements are dismissable by default.
+*****************************************
+
+In 4.0 :ref:`configure_announcements` now have the ability to be ``dismissable``.
+Meaning users can press ``OK`` on the announment and it will no longer appear
+on the pages.
+
+In prior versions of Open OnDemand there was no way to dismiss or get rid of announcements.
+Now in version 4.0, not only is there a way to dismiss announcements, announcements
+themselves are ``dismissable`` by default.
+
+The documentation for :ref:`configure_announcements` has been updated with this new feature.
+
 Dependency updates
 ..................
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/dismissable-announcements/

This adds the 4.0 documentation on announcements. That and updates the announcements configuration table a little bit.
