### PR TITLE
add docs on new data-hide behaviour

### DIFF
--- a/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
+++ b/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
@@ -90,6 +90,11 @@ instructs the webpage to hide the ``cuda_version`` when the ``standard``
   By forcing a value after hiding it you can ensure that the correct values
   are being passed to the server.
 
+.. tip::
+
+  In addition to setting the value to ``true`` to hide the form item, in 4.0
+  you can also specify ``false`` to show the form item.
+
 .. code-block:: yaml
   :emphasize-lines: 7
 

--- a/source/release-notes/v4.0-release-notes.rst
+++ b/source/release-notes/v4.0-release-notes.rst
@@ -15,6 +15,7 @@ New Features
 - `noVNC quality and compression defaults`_
 - `Batch connect sessions poll delay`_
 - `System Status application`_
+- `data-hide directives now respond to false`_
 
 Thanks!
 -------
@@ -159,3 +160,11 @@ update the page. The default is 10 seconds. See :ref:`the documentation on statu
 for more details.
 
 Visit :ref:`disabling_applications` to disable this application.
+
+data-hide directives now respond to false
+.........................................
+
+``data-hide`` directives now respond to both ``true`` to hide
+the form item or ``false`` to show the form item.
+
+Responding to ``false`` is new in 4.0.


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/data-hide-false/

Adds documentation on data-hide directives now responding to `false` as well as `true`.
