### PR TITLE
enable spellcheck in the CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check Spelling
         run: |
-          rake spellcheck || true
+          rake spellcheck
 
       - name: Make Html
         run: |


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/spelling-ci

Fixes #1053 by enabling `spellcheck` in the CI.
