### PR TITLE
Remove old reference to issue #364

### DIFF
--- a/source/installation/resource-manager/test.rst
+++ b/source/installation/resource-manager/test.rst
@@ -50,7 +50,6 @@ configuration files.
       .. code-block:: sh
 
          # [sudo] password for user:
-         # Rails Error: Unable to access log file. Please ensure that /var/www/ood/apps/sys/dashboard/log/production.log exists and is writable (ie, make it writable for user and group: chmod 0664 /var/www/ood/apps/sys/dashboard/log/production.log). The log level has been raised to WARN and the output directed to STDERR until the problem is fixed.
          # mkdir -p /home/user/test_jobs
          # Testing cluster 'cluster1'...
          # Submitting job...
@@ -63,11 +62,6 @@ configuration files.
          # Job has status of completed
          # Test for 'cluster1' PASSED!
          # Finished testing cluster 'cluster1'
-
-   Please **ignore** the ``Rails Error:`` message as this is just a *warning*
-   that doesn't affect your OnDemand installation in any way. We are currently
-   tracking this issue in GitHub at `OSC/dashboard#364
-   <https://github.com/OSC/ood-dashboard/issues/364>`_.
 
    .. tip::
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/latest/installation/resource-manager/test.html

[OSC/dashboard#364](https://github.com/OSC/ood-dashboard/issues/364) was closed in 2018. Removing reference to it and the warning in the code block.

#jam