### PR TITLE
Display current version properly at the bottom left corner

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -153,6 +153,7 @@ html_context = {
     'github_repo': 'ood-documentation',
     'github_version': os.environ.get('OOD_BRANCH', 'develop'),
     'conf_py_path': '/source/',
+    'current_version': release,
     'versions' : [
         ['latest', '/latest/'],
         ['3.0', '/release-3.0/'],


### PR DESCRIPTION
Hi I'm participating the jam. Thanks for coordinating this event! 

This change applies to most any pages in the documentation. 

### before

Before, `current_version` wasn't specified because it's not in the `html_context` in `source/conf.py`: 

https://github.com/OSC/ood-documentation/blob/f3bd2e0eff88c18ba070b169811f9ecdaf111761/source/_templates/versions.html#L1-L6

So the version was not display as expected: 
![Screenshot 2025-03-17 at 3 11 58 PM](https://github.com/user-attachments/assets/100a398e-4285-4eaf-aa04-568149a7a853)


### after

`current_version` was added to the `html_context` in `source/conf.py` and points to `release` in the same file. 

A preview from local build: 
![Screenshot 2025-03-17 at 3 11 47 PM](https://github.com/user-attachments/assets/9943d131-7ab3-4193-8f0e-d9013549b3af)
