### PR TITLE
Replace unfriendly keys for navbar_type

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -180,7 +180,7 @@ Currently only the dashboard uses the colors in the navbar.
      - Value should be URL to logo i.e. ``/public/logo.png``.  the background color the active link in the navbar in the dashboard
    * - Use white text on black background for navbar.
      - ``navbar_type``
-     - By default we use ``inverse`` for this value, which specifies to use `Bootstrap 3's inverted navbar <https://getbootstrap.com/docs/3.3/components/#navbar-inverted>`_ where text is white and background is black (or dark grey). You can set this to ``default`` to use black text on light grey background if it fits your branding better.
+     - By default we use ``dark`` for this value, where text is white and background is black (or dark grey). You can set this to ``light`` to use black text on light grey background if it fits your branding better.
 
 .. note:: It is possible to configure these settings using environment variables, although this is deprecated.
           For information about the properties and environment variables, see the :ref:`OnDemand configuration documentation <ondemand-d-ymls>`.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/latest/customizations.html

The original text says the default is inverse, but you can set it to default if you want other. This is confusing. In the code linked, we have additional more straight forward options of `dark` instead of `inverse` and `light` instead of `default`

https://github.com/OSC/ondemand/blob/4ec6ae009e6886c7d22dfbe16e131d8723cbf979/apps/dashboard/app/models/user_configuration.rb#L93-L107

I also removed URL for bootstrap 3.3, which is outdated. I don't believe a link defining dark and light is required. Also, one less URL to keep up with.