### PR TITLE
Remove TODO for table of contents

### DIFF
--- a/source/installation/resource-manager/kubernetes.rst
+++ b/source/installation/resource-manager/kubernetes.rst
@@ -3,8 +3,6 @@
 Kubernetes
 ==========
 
-TODO table of contents
-
 A YAML cluster configuration file for a Kubernetes resource manager on an HPC
 cluster looks like:
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/latest/installation/resource-manager/kubernetes.html


There's a placeholder of TODO to add a table of contents. We can dynamically add a table of contents using 

```
.. contents:: Table of Contents
   :local:
   :depth: 2
   :backlinks: none
```
Which looks like this,

![Screenshot 2025-03-18 173413](https://github.com/user-attachments/assets/c1cc754b-10df-4eb8-9111-853e1563fdb0)

However, I am unable to make it look nice and compressed like toctree used elsewhere. I also noticed that no other page has a local table of contents. Therefore, I submit the change to remove the placeholder.
