### PR TITLE
Table 2 set header-row

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -65,6 +65,7 @@ the user would see this message at the top of the dashboard:
 If the announcement file has the extension ``yml`` and is a YAML file it is first rendered using ERB and then the resulting file is parsed as YAML. The valid keys are:
 
 .. list-table:: Announcement configuration keys.
+   :header-rows: 1
 
    * - Key
      - Description


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/latest/customizations.html

Set header format for table 2. All other tables have `:header-rows:` set.

