### PR TITLE
Match download limit

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -455,7 +455,7 @@ Note that this will limit the download size for all users of the Open OnDemand i
 
 .. warning::
    This configuration value is expected to be numbers only (no characters)
-   and in units of bytes. The default value of 10737420000 bytes is ~10.7 GB or ~10.0 Gib.
+   and in units of bytes. The default value of 10737418240 bytes is ~10.7 GB or ~10.0 Gib.
 
    Values like ``1000M`` or ``20G`` will not be accepted and may cause errors.
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/latest/customizations.html

Matches the bytes 10737418240 for `OOD_DOWNLOAD_DIR_MAX` mentioned a couple lines above. 

Confirmed this is the bytes max set at [apps/dashboard/config/configuration_singleton.rb](https://github.com/OSC/ondemand/blob/4ec6ae009e6886c7d22dfbe16e131d8723cbf979/apps/dashboard/config/configuration_singleton.rb#L362-L366):

```
  # The maximum size of a .zip file that can be downloaded.
  #
  # Default for OOD_DOWNLOAD_DIR_MAX is 10*1024*1024*1024 bytes.
  # @return [Integer]
  def file_download_dir_max
    ENV['OOD_DOWNLOAD_DIR_MAX']&.to_i || 10737418240
  end
```

Oddly the max upload and downloads differ. [Upload max is 10737420000 bytes](https://github.com/OSC/ondemand/blob/4ec6ae009e6886c7d22dfbe16e131d8723cbf979/apps/dashboard/config/configuration_singleton.rb#L343-L350) while Download max is 10737418240 bytes.
