### PR TITLE
SSH command wrapper update

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -604,9 +604,9 @@ Shell App SSH Command Wrapper
 
 Since OOD 1.7 you can use an ssh wrapper script in the shell application instead of just the ssh command.
 
-This is helpful when you pass add additional environment variable through ssh (``-o SendEnv=MY_ENV_VAR``) or ensure some ssh command options be used.
+This is helpful when you pass additional environment variable through ssh (``-o SendEnv=MY_ENV_VAR``) or ensure some ssh command options be used.
 
-To use your ssh wrapper configure ``OOD_SSH_WRAPPER=/usr/bin/changeme`` to point to your script in ``/etc/ood/config/apps/shell/env``. Also be sure to make your script executable.
+To use your ssh wrapper configure ``OOD_SSH_WRAPPER=/usr/bin/changeme`` in ``/etc/ood/config/apps/shell/env`` to point to your script. Also be sure to make your script executable.
 
 Here's a simple example of what a wrapper script could look like.
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/latest/customizations.html

First is to remove the redundant "add". 
> when you pass ~~add~~ additional environment variable

The second I believe is better structure. When first read I thought we had to place the script in the non-existent folder `/etc/ood/config/apps/shell/env`.
>  configure ``OOD_SSH_WRAPPER=/usr/bin/changeme`` to point to your script in ``/etc/ood/config/apps/shell/env``.

#jam