### PR TITLE
Adding Ubuntu session for SAML authentication

### DIFF
--- a/source/authentication/adfs-with-auth-mellon.rst
+++ b/source/authentication/adfs-with-auth-mellon.rst
@@ -84,7 +84,7 @@ user on the OOD host. For more information, see https://jdennis.fedorapeople.org
 
         .. tab:: Ubuntu
 
-            There is a known problem on mellon_create_metadata in ubuntu. If the xml generation fails silently try to apply the solution described at https://bugs.launchpad.net/ubuntu/+source/ssl-cert/+bug/1945774/comments/8
+            There is a known problem on mellon_create_metadata in Ubuntu. If the xml generation fails silently try to apply the solution described at https://bugs.launchpad.net/ubuntu/+source/ssl-cert/+bug/1945774/comments/8
 
             .. code-block:: shell
 

--- a/source/authentication/adfs-with-auth-mellon.rst
+++ b/source/authentication/adfs-with-auth-mellon.rst
@@ -3,7 +3,7 @@
 SAML Authentication with Active Directory Federated Services (ADFS) and mod_auth_mellon
 ========================================================================================
 
-The following details how to use ADFS infrastructure via SAML authentication to authenticate to an OpenOnDemand deployment. 
+The following details how to use ADFS infrastructure via SAML authentication to authenticate to an OpenOnDemand deployment.
 
 Prepare the Host
 --------------------------------------------------
@@ -42,52 +42,114 @@ Install mod_auth_mellon
 Configure mod_auth_mellon
 --------------------------------------------------
 
-Note that this configuration assumes that SAML has been configured such that the returned NameID directly maps to a Unix user on the OOD host. For more information, see https://jdennis.fedorapeople.org/doc/mellon-user-guide/mellon_user_guide.html
+Note that this configuration assumes that SAML has been configured such that the returned NameID directly maps to a Unix
+user on the OOD host. For more information, see https://jdennis.fedorapeople.org/doc/mellon-user-guide/mellon_user_guide.html
+
+#. Change to apache's etc directory
+
+    .. tabs::
+
+       .. tab:: EL7/EL8+
+
+         .. code-block:: shell
+
+            mkdir -p /etc/httpd/mellon/
+            cd /etc/httpd/mellon/
+
+       .. tab:: Ubuntu
+
+         .. code-block:: shell
+
+            mkdir -p /etc/apache2/mellon/
+            cd /etc/apache2/mellon/
+       		     
 
 #. Download the IDP metadata file
 
    .. code-block:: shell
-
-      cd /etc/httpd/mellon/
-      wget https://adfs.organization.com/ADFS/metadata.xml -O idpmetadata.xml
+		   
+        wget https://adfs.organization.com/ADFS/metadata.xml -O idpmetadata.xml
 
 #. Generate the mellon metadata
 
-   .. code-block:: shell
+    .. tabs::
+        .. tab:: EL7/EL8+
+           .. code-block:: shell
 
-      export mellon_endpoint="https://$(hostname)/mellon"
-      /usr/libexec/mod_auth_mellon/mellon_create_metadata.sh "${mellon_endpoint}/metadata" "${mellon_endpoint}"
-      mv *.cert ./mellon.cert
-      mv *.key ./mellon.key
-      mv *.xml ./mellon_metadata.xml
+              export mellon_endpoint="https://$(hostname)/mellon"
+              /usr/libexec/mod_auth_mellon/mellon_create_metadata.sh "${mellon_endpoint}/metadata" "${mellon_endpoint}"
+              mv *.cert ./mellon.cert
+              mv *.key ./mellon.key
+              mv *.xml ./mellon_metadata.xml
+
+        .. tab:: Ubuntu
+
+            There is a known problem on mellon_create_metadata in ubuntu. If the xml generation fails silently try to apply the solution described at https://bugs.launchpad.net/ubuntu/+source/ssl-cert/+bug/1945774/comments/8
+
+            .. code-block:: shell
+
+                export mellon_endpoint="https://$(hostname)/mellon"
+                /usr/sbin/mellon_create_metadata "${mellon_endpoint}/metadata" "${mellon_endpoint}"
+                mv *.cert ./mellon.cert
+                mv *.key ./mellon.key
+                mv *.xml ./mellon_metadata.xml
 
 #. Create a mellon configuration file
+    .. tabs::
+        .. tab:: EL7/EL8+
+            .. code-block:: shell
 
-   .. code-block:: shell
+                vi /etc/httpd/conf.d/00-mellon.conf
 
-      vi /etc/httpd/conf.d/00-mellon.conf
+        .. tab:: Ubuntu
+            .. code-block:: shell
 
-#. Add the following to the ``00-mellon.conf`` file
+                vi /etc/apache2/conf-available/mellon.conf
 
-   .. code-block:: xml
+#. Add the following to the apache mellon's configuration file
+    .. tabs::
 
-      <Location />
-        MellonSPPrivateKeyFile /etc/httpd/mellon/mellon.key
-        MellonSPCertFile /etc/httpd/mellon/mellon.cert
-        MellonSPMetadataFile /etc/httpd/mellon/mellon_metadata.xml
-        MellonIdPMetadataFile /etc/httpd/mellon/idpmetadata.xml
+        .. tab:: EL7/EL8+
 
-        MellonEndpointPath /mellon
-        MellonEnable "auth"
-      </Location>
+           .. code-block:: xml
+
+              <Location />
+                MellonSPPrivateKeyFile /etc/httpd/mellon/mellon.key
+                MellonSPCertFile /etc/httpd/mellon/mellon.cert
+                MellonSPMetadataFile /etc/httpd/mellon/mellon_metadata.xml
+                MellonIdPMetadataFile /etc/httpd/mellon/idpmetadata.xml
+
+                MellonEndpointPath /mellon
+                MellonEnable "auth"
+              </Location>
+
+        .. tab:: Ubuntu
+
+            .. code-block:: xml
+
+              <Location />
+                MellonSPPrivateKeyFile /etc/apache2/mellon/mellon.key
+                MellonSPCertFile /etc/apache2/mellon/mellon.cert
+                MellonSPMetadataFile /etc/apache2/mellon/mellon_metadata.xml
+                MellonIdPMetadataFile /etc/apache2/mellon/idpmetadata.xml
+
+                MellonEndpointPath /mellon
+                MellonEnable "auth"
+              </Location>
 
 #. Convert the key and cert files into PFX format
+    .. tabs::
+        .. tab:: EL7/EL8+
+           .. code-block:: shell
 
-   .. code-block:: shell
+              openssl pkcs12 -export -inkey /etc/httpd/mellon/mellon.key -in /etc/httpd/mellon/mellon.cert -out /etc/httpd/mellon/mellon.pfx
 
-      openssl pkcs12 -export -inkey /etc/httpd/mellon/mellon.key -in /etc/httpd/mellon/mellon.cert -out /etc/httpd/mellon/mellon.pfx
+        .. tab:: Ubuntu
+           .. code-block:: shell
 
-#. Provide the ``mellon.pfx`` and ``mellon_metadata.xml`` files to your ADFS administrator. The files can then be imported into the ADFS system. 
+              openssl pkcs12 -export -inkey /etc/apache2/mellon/mellon.key -in /etc/apache2/mellon/mellon.cert -out /etc/apache2/mellon/mellon.pfx
+
+#. Provide the ``mellon.pfx`` and ``mellon_metadata.xml`` files to your ADFS administrator. The files can then be imported into the ADFS system.
 
 Configure OOD
 --------------------------------------------------
@@ -107,7 +169,13 @@ Configure OOD
         - 'Require valid-user'
 
 #. Restart the HTTPD
+    .. tabs::
+        .. tab:: EL7/EL8+
+           .. code-block:: shell
 
-   .. code-block:: shell
+                systemctl restart httpd
 
-      systemctl restart httpd
+        .. tab:: Ubuntu
+           .. code-block:: shell
+
+                systemctl restart apache2


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/latest/authentication/adfs-with-auth-mellon.html

**Add your description here**

Adding specific paths, commands and quirks when configuring SAML (mellon) in Ubuntu.
