### PR TITLE
Small documentation tweaks resolving #1117 and #1116

### DIFF
--- a/source/install-ihpc-apps.rst
+++ b/source/install-ihpc-apps.rst
@@ -8,7 +8,7 @@ template and modifying it to work at your center. See
 :ref:`app-development-tutorials-interactive-apps-add-jupyter` to install
 Jupyter.
 
-If you have developed an app and would like to contribute it to the community, please post a description and link to the app to https://discourse.osc.edu/c/open-ondemand.
+If you have developed an app and would like to contribute it to the community, please post a description and link to the app to https://discourse.openondemand.org.
 In order to submit the code of an interactive app that you developed to the GitHub repository, it should be available on the developer’s GitHub and well commented. The comments need to include, but not limited to, mentioning if there are parts of the app that are site-specific. Also, the following files must be included:
 
 - LICENSE file - the license should be open source. If you are not sure what to choose, OnDemand uses MIT License.

--- a/source/tutorials/tutorials-passenger-apps/python-starter-app.rst
+++ b/source/tutorials/tutorials-passenger-apps/python-starter-app.rst
@@ -79,8 +79,8 @@ required libraries. Here, we're only adding ``flask`` of any version.
   source python-hello-world/bin/activate
   python3 -m pip install -r requirements.txt
 
-Create the python files
-```````````````````````
+Create application files
+````````````````````````
 
 In the basic example above, the entire implementation is held within a ``passenger_wsgi.py``.
 This project is more advanced, so it will include two files. ``passenger_wsgi.py`` and

--- a/source/tutorials/tutorials-passenger-apps/python-starter-app.rst
+++ b/source/tutorials/tutorials-passenger-apps/python-starter-app.rst
@@ -45,6 +45,7 @@ When the new tab opens you should see a mostly blank page with the something
 like the following:
 
 .. code:: shell
+    
   Hello World from Open OnDemand (Python WSGI)!
   3.9.21 (main, Dec  5 2024, 00:00:00) 
   [GCC 11.5.0 20240719 (Red Hat 11.5.0-2)]

--- a/source/tutorials/tutorials-passenger-apps/python-starter-app.rst
+++ b/source/tutorials/tutorials-passenger-apps/python-starter-app.rst
@@ -41,8 +41,15 @@ in the ``Develop`` menu of your OnDemand installation.
 There you should see this application at the top of the list.  Clicking
 ``Launch Python Hello World`` will launch this application in a new tab.
 
-When the new tab opens you should see a blank page with the text ``Hello World``
-with some extra text about the system. This is your new `Python`_ application!
+When the new tab opens you should see a mostly blank page with the something
+like the following:
+
+.. code:: shell
+  Hello World from Open OnDemand (Python WSGI)!
+  3.9.21 (main, Dec  5 2024, 00:00:00) 
+  [GCC 11.5.0 20240719 (Red Hat 11.5.0-2)]
+
+This is your new `Python`_ application!
 
 
 Application using Flask and a virtual environment
@@ -66,13 +73,25 @@ to create one. This will create a subdirectory ``python-hello-world`` with a
 
   python3 -m venv python-hello-world
 
-Now, let's create the ``requriements.txt`` file where we'll add the application's
+You can also use other Python virtual environment managers such as ``uv``. If you
+have ``uv`` installed, the following command will create a virtual environment 
+subdirectory ``.venv``.
+
+.. code:: shell
+  uv venv
+
+Install required packages
+`````````````````````````
+
+Now, let's create the ``requirements.txt`` file where we'll add the application's
 required libraries. Here, we're only adding ``flask`` of any version.
 
 .. code:: text
 
   # requirements.txt
   flask
+
+Activate environment and install requirements.txt
 
 .. code:: shell
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/latest/

**Add your description here**
Small documentation tweaks hopefully resolving the issues I had with my previous PRs #1117 and #1116. These documentation changes are small, fixing typos, 404 links, and adding some clarity when creating a Python passenger app.