### PR TITLE
Remove auth from OIDCProviderMetadataURL

### DIFF
--- a/source/authentication/tutorial-oidc-keycloak-rhel7/install_mod_auth_openidc.rst
+++ b/source/authentication/tutorial-oidc-keycloak-rhel7/install_mod_auth_openidc.rst
@@ -107,7 +107,7 @@ Add Keycloak configuration to OnDemand Apache for ``mod_auth_openidc``
 
    .. code-block:: none
 
-     OIDCProviderMetadataURL https://ondemand-idpdev.hpc.osc.edu/auth/realms/ondemand/.well-known/openid-configuration
+     OIDCProviderMetadataURL https://ondemand-idpdev.hpc.osc.edu/realms/ondemand/.well-known/openid-configuration
      OIDCClientID        "ondemand-dev.hpc.osc.edu"
      OIDCClientSecret    "1111111-1111-1111-1111-111111111111"
      OIDCRedirectURI      https://ondemand-dev.hpc.osc.edu/oidc


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

branch: https://osc.github.io/ood-documentation/latest   
page: source/authentication/tutorial-oidc-keycloak-rhel7/install_mod_auth_openidc.rst

**Add your description here**

Currently troubleshooting our own ood/keycloak setup. I hope this PR will fix the issue from [this discourse post](https://discourse.openondemand.org/t/keycloak-on-ondemand-having-issue/3049/15?u=jennyfothergill)