### PR TITLE
Document app caption option in manifest YAML files

### DIFF
--- a/source/how-tos/app-development/interactive/form-widgets.rst
+++ b/source/how-tos/app-development/interactive/form-widgets.rst
@@ -134,6 +134,9 @@ Form Widgets
     This is useful in forms where a path must be selected and you
     want to allow your users to choose an arbitrary path.
 
+    In order to add, remove, or edit the Path Selector, navigate to 
+    its ``form.yml`` file to make any appropriate changes. 
+
     ``directory`` is the initial directory the path selector will open
     to when the users opens the modal. This defaults to the users' HOME.
 

--- a/source/how-tos/app-development/interactive/manifest.rst
+++ b/source/how-tos/app-development/interactive/manifest.rst
@@ -44,5 +44,6 @@ to the Open OnDemand platform.
 ``new_window`` (Optional)
   A boolean (``true`` or ``false``) flag to toggle if the app should open a new
   window when clicked.
-
+``caption`` (Optional)
+  A short caption for the app. Setting this overrides the default. This will be shown on the Dashboard within the app launcher button. If not set the caption will default to "System Installed App".
 


### PR DESCRIPTION
Update to https://osc.github.io/ood-documentation/latest/how-tos/app-development/interactive/manifest.html

Document app caption option in manifest YAML files
As fixed in https://github.com/OSC/ondemand/issues/1900 and https://github.com/OSC/ondemand/pull/1941 it is now possible to override the default System Installed App caption in app launcher buttons. Documenting this option.