### PR TITLE
Document app caption option in manifest YAML files (:latest)

### DIFF
--- a/source/how-tos/app-development/interactive/manifest.rst
+++ b/source/how-tos/app-development/interactive/manifest.rst
@@ -44,5 +44,6 @@ to the Open OnDemand platform.
 ``new_window`` (Optional)
   A boolean (``true`` or ``false``) flag to toggle if the app should open a new
   window when clicked.
-
+``caption`` (Optional)
+  A short caption for the app. Setting this overrides the default. This will be shown on the Dashboard within the app launcher button. If not set the caption will default to "System Installed App".
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -6,7 +6,7 @@ Installation
 The OnDemand host machine needs to be setup *similarly* to a login node. This
 means that it will need:
 
-- RedHat/RockyLinux/AlmaLinux 8+ or Ubuntu 20.04-24.04 or Debian 12 or Amazon Linux 2023
+- RedHat/RockyLinux/AlmaLinux 8+ or Ubuntu 22.04-24.04 or Debian 12 or Amazon Linux 2023
 - the resource manager (e.g., Torque, Slurm, or LSF) client binaries and
   libraries used by the batch servers installed
 - configuration on both OnDemand node **and batch servers** to be able to

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -86,17 +86,6 @@ Open OnDemand uses these packages, among many others.
 
             sudo dnf install ondemand
 
-      .. tab:: Ubuntu 20.04
-
-         .. code-block:: sh
-
-            sudo apt install apt-transport-https ca-certificates
-            wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.0-focal_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.0-focal_all.deb
-            sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.0-focal_all.deb
-            sudo apt update
-
-            sudo apt install ondemand
-
       .. tab:: Ubuntu 22.04
 
          .. code-block:: sh

--- a/source/requirements.rst
+++ b/source/requirements.rst
@@ -19,7 +19,6 @@ At this time OnDemand only supports the following operating systems and architec
 
    "RedHat/Rocky Linux/AlmaLinux 8",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#9989;`
    "RedHat/Rocky Linux/AlmaLinux 9",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#9989;`
-   "Ubuntu 20.04",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#10060;`
    "Ubuntu 22.04",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#10060;`
    "Ubuntu 24.04",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#10060;`
    "Debian 12",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#10060;`


### PR DESCRIPTION
Branch: https://github.com/ndjones/ood-documentation/tree/docs-caption-app-manifest-option

Update to https://osc.github.io/ood-documentation/latest/how-tos/app-development/interactive/manifest.html

Document app caption option in manifest YAML files
As fixed in https://github.com/OSC/ondemand/issues/1900 and https://github.com/OSC/ondemand/pull/1941 it is now possible to override the default System Installed App caption in app launcher buttons. Documenting this option.