### PR TITLE
Document app caption option in manifest YAML files

### DIFF
--- a/source/how-tos/app-development/interactive/manifest.rst
+++ b/source/how-tos/app-development/interactive/manifest.rst
@@ -44,5 +44,6 @@ to the Open OnDemand platform.
 ``new_window`` (Optional)
   A boolean (``true`` or ``false``) flag to toggle if the app should open a new
   window when clicked.
-
+``caption`` (Optional)
+  A short caption for the app. Setting this overrides the default. This will be shown on the Dashboard within the app launcher button. If not set the caption will default to "System Installed App".
 


### PR DESCRIPTION
As fixed in https://github.com/OSC/ondemand/issues/1900 and https://github.com/OSC/ondemand/pull/1941 it is now possible to override the default System Installed App caption in app launcher buttons. Documenting this option.

**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/BRANCH-NAME/

**Add your description here**
