### PR TITLE
Add popup_title to path_selector

### DIFF
--- a/source/how-tos/app-development/interactive/form-widgets.rst
+++ b/source/how-tos/app-development/interactive/form-widgets.rst
@@ -146,6 +146,9 @@ Form Widgets
     ``show_files`` is a boolean flag to show files or not. This defaults
     to true - it will show files.
 
+    ``popup_title`` is the title displayed in the modal. Default is 
+    "Select Your Working Directory".
+
     ``favorites`` allows you to override the :ref:`favorite paths you've added
     in files menu <add-shortcuts-to-files-menu>`.  Provide an array of new favorites
     or set to ``false`` to disable showing favorites altogether.
@@ -157,6 +160,7 @@ Form Widgets
           directory: "/fs/ess/project"
           show_hidden: true
           show_files: false
+          popup_title: "Select the Folder"
           favorites:
             - /fs/ess
             - /fs/scratch


### PR DESCRIPTION
https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form-widgets.html

Adds documentation for the `popup_title` option for the path selector widget introduced in https://github.com/OSC/ondemand/pull/4426
