### PR TITLE
Update Dockerfile URL

### DIFF
--- a/source/how-tos/app-development/interactive/form-widgets.rst
+++ b/source/how-tos/app-development/interactive/form-widgets.rst
@@ -146,6 +146,9 @@ Form Widgets
     ``show_files`` is a boolean flag to show files or not. This defaults
     to true - it will show files.
 
+    ``popup_title`` is the title displayed in the modal. Default is 
+    "Select Your Working Directory".
+
     ``favorites`` allows you to override the :ref:`favorite paths you've added
     in files menu <add-shortcuts-to-files-menu>`.  Provide an array of new favorites
     or set to ``false`` to disable showing favorites altogether.
@@ -157,6 +160,7 @@ Form Widgets
           directory: "/fs/ess/project"
           show_hidden: true
           show_files: false
+          popup_title: "Select the Folder"
           favorites:
             - /fs/ess
             - /fs/scratch

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -6,7 +6,7 @@ Installation
 The OnDemand host machine needs to be setup *similarly* to a login node. This
 means that it will need:
 
-- RedHat/RockyLinux/AlmaLinux 8+ or Ubuntu 20.04-24.04 or Debian 12 or Amazon Linux 2023
+- RedHat/RockyLinux/AlmaLinux 8+ or Ubuntu 22.04-24.04 or Debian 12 or Amazon Linux 2023
 - the resource manager (e.g., Torque, Slurm, or LSF) client binaries and
   libraries used by the batch servers installed
 - configuration on both OnDemand node **and batch servers** to be able to

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -32,9 +32,9 @@ Building From Source
 Building from source is left as an exercise to the reader. 
      
 It's not particularly difficult to build the code, but installing it with all the various files is. Should you be interested, 
-review the ``Dockerfile`` and packaging specs for what would be involved.
+review the ``Dockerfile.example`` and packaging specs for what would be involved.
 
-- https://github.com/OSC/ondemand/blob/master/Dockerfile
+- https://github.com/OSC/ondemand/blob/master/Dockerfile.example
 - https://github.com/OSC/ondemand/tree/master/packaging
 
 If you'd like a package built for a system that we don't currently support, feel free to open a ticket!

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -86,17 +86,6 @@ Open OnDemand uses these packages, among many others.
 
             sudo dnf install ondemand
 
-      .. tab:: Ubuntu 20.04
-
-         .. code-block:: sh
-
-            sudo apt install apt-transport-https ca-certificates
-            wget -O /tmp/ondemand-release-web_{{ ondemand_version }}.0-focal_all.deb https://apt.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web_{{ ondemand_version }}.0-focal_all.deb
-            sudo apt install /tmp/ondemand-release-web_{{ ondemand_version }}.0-focal_all.deb
-            sudo apt update
-
-            sudo apt install ondemand
-
       .. tab:: Ubuntu 22.04
 
          .. code-block:: sh

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -74,6 +74,7 @@ Open OnDemand uses these packages, among many others.
 
          .. code-block:: sh
 
+            sudo rpm --import https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand
             sudo dnf install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-1.el8.noarch.rpm
 
             sudo dnf install ondemand
@@ -82,6 +83,7 @@ Open OnDemand uses these packages, among many others.
 
          .. code-block:: sh
 
+            sudo rpm --import https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512
             sudo dnf install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-1.el9.noarch.rpm
 
             sudo dnf install ondemand
@@ -123,6 +125,7 @@ Open OnDemand uses these packages, among many others.
 
          .. code-block:: sh
 
+            sudo rpm --import https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512
             sudo dnf install https://yum.osc.edu/ondemand/{{ ondemand_version }}/ondemand-release-web-{{ ondemand_version }}-1.amzn2023.noarch.rpm
 
             sudo dnf install ondemand

--- a/source/requirements.rst
+++ b/source/requirements.rst
@@ -19,7 +19,6 @@ At this time OnDemand only supports the following operating systems and architec
 
    "RedHat/Rocky Linux/AlmaLinux 8",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#9989;`
    "RedHat/Rocky Linux/AlmaLinux 9",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#9989;`
-   "Ubuntu 20.04",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#10060;`
    "Ubuntu 22.04",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#10060;`
    "Ubuntu 24.04",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#10060;`
    "Debian 12",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#10060;`


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/latest/installation.html

This [pull request](https://github.com/OSC/ondemand/commit/dd8d917ce65f5c3b9637061bec1d702086ae0e12#diff-2604174ad4aece255b429040694aee0bc73b8b951ffacef5b9968935d59a4ea2) moved Dockerfile to Dockerfile.example. This update  fixes the URL and filename on the installation page.
