### PR TITLE
Update Dockerfile URL

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -32,9 +32,9 @@ Building From Source
 Building from source is left as an exercise to the reader. 
      
 It's not particularly difficult to build the code, but installing it with all the various files is. Should you be interested, 
-review the ``Dockerfile`` and packaging specs for what would be involved.
+review the ``Dockerfile.example`` and packaging specs for what would be involved.
 
-- https://github.com/OSC/ondemand/blob/master/Dockerfile
+- https://github.com/OSC/ondemand/blob/master/Dockerfile.example
 - https://github.com/OSC/ondemand/tree/master/packaging
 
 If you'd like a package built for a system that we don't currently support, feel free to open a ticket!


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/latest/installation.html

This [pull request](https://github.com/OSC/ondemand/commit/dd8d917ce65f5c3b9637061bec1d702086ae0e12#diff-2604174ad4aece255b429040694aee0bc73b8b951ffacef5b9968935d59a4ea2) moved Dockerfile to Dockerfile.example. This update fixes the URL and filename on the installation page.