### PR TITLE
Fix osc-systemstatus URL

### DIFF
--- a/source/release-notes/v4.0-release-notes.rst
+++ b/source/release-notes/v4.0-release-notes.rst
@@ -496,4 +496,4 @@ Upgrade Instructions
 
       sudo dnf downgrade mod_auth_openidc
 
-.. _OSC System Status application: https://github.com/osc/osc-systemstatus.
+.. _OSC System Status application: https://github.com/osc/osc-systemstatus


### PR DESCRIPTION
https://osc.github.io/ood-documentation/latest/release-notes/v4.0-release-notes.html#system-status-application

The original link has a period (.) at the end and takes you to `https://github.com/osc/osc-systemstatus.` which fails. Removing that period to take you to https://github.com/osc/osc-systemstatus
