### PR TITLE
document usage of `placeholder` attribute

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -475,11 +475,11 @@ are:
           placeholder: null
 
      Example
-       Display default value in placeholder
+       Display recommended value in placeholder
 
        .. code-block:: yaml
 
-          placeholder: "Default: 4"
+          placeholder: "Recommended: 4"
 
 .. describe:: pattern (String, null)
 

--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -465,7 +465,7 @@ are:
 
 .. describe:: placeholder (String, null)
 
-     help text that appears inside the field when it is empty
+     Example or hint text that is shown inside the field with low contrast when it is empty.
 
      Default
        No help text appears in input field

--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -479,7 +479,7 @@ are:
 
        .. code-block:: yaml
 
-          pattern: "Default: 4"
+          placeholder: "Default: 4"
 
 .. describe:: pattern (String, null)
 

--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -463,6 +463,24 @@ are:
             - `blue`
             - `green`
 
+.. describe:: placeholder (String, null)
+
+     help text that appears inside the field when it is empty
+
+     Default
+       No help text appears in input field
+
+       .. code-block:: yaml
+
+          placeholder: null
+
+     Example
+       Display default value in placeholder
+
+       .. code-block:: yaml
+
+          pattern: "Default: 4"
+
 .. describe:: pattern (String, null)
 
      a regular expression that the control's value is checked against (only

--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -358,12 +358,12 @@ are:
 
      - ``check_box``
      - ``hidden_field``
-     - ``number_field`` - can use ``min``, ``max``, ``step``
+     - ``number_field`` - can use ``min``, ``max``, ``step``, ``placeholder``
      - ``radio_button``    
      - ``resolution_field`` (used for specifying resolution dimensions necessary for VNC)
      - ``select`` - can use ``options``
-     - ``text_area``
-     - ``text_field``
+     - ``text_area`` - can use ``placeholder``
+     - ``text_field`` - can use ``pattern``, ``placeholder``
 
      Some other fields that have varying support across different browsers
      include: ``range_field``, ``date_field``, ``search_field``,


### PR DESCRIPTION
as a workaround for https://github.com/OSC/ondemand/issues/3636, I display the default value in the placeholder, and in `submit.yml.erb` I use those default values for fields left blank. I also made sure not to use the `required` attribute, and added a message to `form_header` saying that it's OK to leave fields blank.