### PR TITLE
change edit on github to 'latest' instead of 'develop'

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -151,7 +151,7 @@ html_context = {
     'display_github': True,
     'github_user': 'OSC',
     'github_repo': 'ood-documentation',
-    'github_version': os.environ.get('OOD_BRANCH', 'develop'),
+    'github_version': os.environ.get('OOD_BRANCH', 'latest'),
     'conf_py_path': '/source/',
     'current_version': release,
     'versions' : [


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/johrstrom-patch-1/

Change edit on github to the 'latest' branch instead of 'develop'. This is because folks who use this button to suggest an edit are in fact mostly trying to edit the current/latest version of the documentation, not what's upcoming. So this link should reflect that.
