### PR TITLE
Set example TurboVNC directory to the default installation path rather than /usr/local

### DIFF
--- a/source/how-tos/app-development/interactive/setup/enable-reverse-proxy.rst
+++ b/source/how-tos/app-development/interactive/setup/enable-reverse-proxy.rst
@@ -53,7 +53,7 @@ Requirements
             vnc:
               script_wrapper: |
                 module purge
-                export PATH="/usr/local/turbovnc/bin:$PATH"
+                export PATH="/opt/TurboVNC/bin:$PATH"
                 export WEBSOCKIFY_CMD="/usr/local/websockify/run"
                 %s
               set_host: "host=$(hostname -A | awk '{print $1}')"

--- a/source/how-tos/app-development/interactive/setup/enable-reverse-proxy.rst
+++ b/source/how-tos/app-development/interactive/setup/enable-reverse-proxy.rst
@@ -53,6 +53,7 @@ Requirements
             vnc:
               script_wrapper: |
                 module purge
+                # Add the TurboVNC installation directory to the PATH (note: this may be different on your system)
                 export PATH="/opt/TurboVNC/bin:$PATH"
                 export WEBSOCKIFY_CMD="/usr/local/websockify/run"
                 %s

--- a/source/how-tos/app-development/interactive/setup/modify-cluster-configuration.rst
+++ b/source/how-tos/app-development/interactive/setup/modify-cluster-configuration.rst
@@ -32,7 +32,7 @@ This is a simple example that ensures modules are always being purged and
        vnc:
          script_wrapper: |
            module purge
-           export PATH="/usr/local/turbovnc/bin:$PATH"
+           export PATH="/opt/TurboVNC/bin:$PATH"
            export WEBSOCKIFY_CMD="/usr/local/websockify/run"
            %s
 

--- a/source/how-tos/app-development/interactive/setup/modify-cluster-configuration.rst
+++ b/source/how-tos/app-development/interactive/setup/modify-cluster-configuration.rst
@@ -32,6 +32,7 @@ This is a simple example that ensures modules are always being purged and
        vnc:
          script_wrapper: |
            module purge
+           # Add the TurboVNC installation directory to the PATH (note: this may be different on your system)
            export PATH="/opt/TurboVNC/bin:$PATH"
            export WEBSOCKIFY_CMD="/usr/local/websockify/run"
            %s


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/turbovnc-docs/how-tos/app-development/interactive/setup/modify-cluster-configuration.html

**Add your description here**
Using a local path without explicitly denoting it as such is confusing to users. I have set it to the default TurboVNC installation directory - alternative may be to call this out specifically.