### PR TITLE
Document OOD_SHELL_TERM

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -599,6 +599,11 @@ connection alive is not factored into this.
 of activity (in milliseconds). After this duration, the connection will be closed
 regardless of activity. Its default is 3600000 milliseconds (1 hour).
 
+``OOD_SHELL_TERM`` allows the default ``TERM=xterm-16color`` to be overriden. Should only
+be set to ones whose escape codes are fully supported by the underlying
+`hterm library <https://chromium.googlesource.com/apps/libapps/+/HEAD/hterm/docs/ControlSequences.md>`__.
+Some other common ones that are include ``xterm``, ``xterm-256color``, and ``xterm-direct``.
+
 .. code:: shell
 
   # /etc/ood/config/apps/shell/env


### PR DESCRIPTION
Tagged need doc [here](https://github.com/OSC/ondemand/pull/4504). Haven't actually tested that it all builds okay still, but it seemed pretty straightforward.

The one thing I wasn't sure of is if should have used a single `_` instead of a double `__` for the hterm link? Wasn't sure , but [stack overflow](https://stackoverflow.com/questions/17189038/generating-an-external-link-in-sphinx) said the double avoids generating a target, which seemed probably correct.