### PR TITLE
Spellcheck OIDC redirect uri

### DIFF
--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -948,7 +948,7 @@ on mod_auth_openidc_.
 
 .. describe:: oidc_redirect_uri (String, null)
 
-     Sub-uri used by mod_auth_openidc_ to populate OIDCRedirectURI
+     Sub URI used by mod_auth_openidc_ to populate OIDCRedirectURI
 
      Default
        This defaults to 

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -946,6 +946,24 @@ on mod_auth_openidc_.
 
           oidc_uri: "/oidc"
 
+.. describe:: oidc_redirect_uri (String, null)
+
+     Sub-uri used by mod_auth_openidc_ to populate OIDCRedirectURI
+
+     Default
+       This defaults to 
+
+       .. code-block:: yaml
+
+          oidc_redirect_uri: /oidc
+
+     Example
+       Enable it on a recommended URI
+
+       .. code-block:: yaml
+
+          oidc_redirect_uri: "https://rproxy-example-uri.com/oidc"
+
 .. describe:: oidc_discover_uri (String, null)
 
      the URI a user is redirected to if they are not authenticated by


### PR DESCRIPTION

https://osc.github.io/ood-documentation-test/develop/](https://osc.github.io/ood-documentation-test/develop/reference/files/ood-portal-yml.html


Fixes incorrect spelling for URI according to `spelling_wordlist.txt`