### PR TITLE
fixes incorrect spelling  in oidc_redirect_uri reference

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -599,7 +599,7 @@ connection alive is not factored into this.
 of activity (in milliseconds). After this duration, the connection will be closed
 regardless of activity. Its default is 3600000 milliseconds (1 hour).
 
-``OOD_SHELL_TERM`` allows the default ``TERM=xterm-16color`` to be overriden. Should only
+``OOD_SHELL_TERM`` allows the default ``TERM=xterm-16color`` to be overridden. Should only
 be set to ones whose escape codes are fully supported by the underlying
 `hterm library <https://chromium.googlesource.com/apps/libapps/+/HEAD/hterm/docs/ControlSequences.md>`__.
 Some other common ones that are include ``xterm``, ``xterm-256color``, and ``xterm-direct``.

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -948,7 +948,7 @@ on mod_auth_openidc_.
 
 .. describe:: oidc_redirect_uri (String, null)
 
-     Sub-uri used by mod_auth_openidc_ to populate OIDCRedirectURI.
+     Sub URI used by mod_auth_openidc_ to populate OIDCRedirectURI
 
      Default
        This defaults to: 

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -948,7 +948,7 @@ on mod_auth_openidc_.
 
 .. describe:: oidc_redirect_uri (String, null)
 
-     Sub URI used by mod_auth_openidc_ to populate OIDCRedirectURI
+     Sub-URI used by mod_auth_openidc_ to populate OIDCRedirectURI
 
      Default
        This defaults to: 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/fix-develop/

Supersedes #1173 to fix the develop branch spelling errors.
