### PR TITLE
Init adapters

### DIFF
--- a/source/installation/add-cluster-config.rst
+++ b/source/installation/add-cluster-config.rst
@@ -81,6 +81,8 @@ client binaries.
    resource-manager/kubernetes
    resource-manager/coder
    resource-manager/systemd
+   resource-manager/ht-condor
+   resource-manager/psi-j
    resource-manager/bin-override-example
    resource-manager/test
    resource-manager/advanced-configs

--- a/source/installation/resource-manager/coder.rst
+++ b/source/installation/resource-manager/coder.rst
@@ -3,6 +3,8 @@
 Coder
 ==========
 
+.. include:: limited-support.inc
+
 The Coder adapter enables launching virtual machines from Open OnDemand using Coder as a middleware solution. Coder is an open-source platform that allows users to create and manage developer workspaces by executing Terraform/OpenTofu code, serving as a bridge between Open OnDemand and cloud providers. Currently, OpenStack is the supported cloud provider.
 
 A YAML cluster configuration file for a Coder is defined by:

--- a/source/installation/resource-manager/ht-condor.rst
+++ b/source/installation/resource-manager/ht-condor.rst
@@ -1,0 +1,8 @@
+.. _resource-manager-ht-condor:
+
+HT Condor
+=========
+
+.. include:: limited-support.inc
+
+This was a community contribution and documentation is needed.

--- a/source/installation/resource-manager/psi-j.rst
+++ b/source/installation/resource-manager/psi-j.rst
@@ -1,0 +1,8 @@
+.. _resource-manager-psi-j:
+
+PSI/J
+=====
+
+.. include:: limited-support.inc
+
+This was a community contribution and documentation is needed.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/init-adapters/

Initialize docs for a couple adapters. This also adds the limited support note for the coder adapter.

Not really sure what else to put in these pages beyond `This was a community contribution and documentation is needed.`. 
