### PR TITLE
update websockify min version to 0.13.0

### DIFF
--- a/source/how-tos/app-development/interactive/setup/software-requirements.rst
+++ b/source/how-tos/app-development/interactive/setup/software-requirements.rst
@@ -12,7 +12,7 @@ For VNC server support:
 
 - `nmap-ncat`_
 - `TurboVNC`_ 2.1+
-- `websockify`_ 0.8.0+
+- `websockify`_ 0.13.0+
 
 .. warning::
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/websockify-version/

Specify the minimum version for websockify to be `0.13.0` as lower versions have issues.
