### PR TITLE
Add page to list community-developed Passenger Apps

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -72,6 +72,7 @@ These are institutions who were early adopters or provided HPC resources for dev
 
 
   install-ihpc-apps
+  install-passenger-apps
   tutorials/tutorials-interactive-apps
   tutorials/tutorials-passenger-apps
   tutorials/tutorials-dashboard-apps

--- a/source/install-ihpc-apps.rst
+++ b/source/install-ihpc-apps.rst
@@ -156,4 +156,10 @@ interactive apps that are currently deployed at OSC and other contributing insti
      - https://github.com/OSC/bc_osc_codeserver 
      - no
      - rnode
+     -
+   * - EESSI_APP
+     - doitnow
+     - https://github.com/doitnowgroup/openondemand-app-collection/tree/main/EESSI_APP
+     - no
+     - noVNC
   

--- a/source/install-ihpc-apps.rst
+++ b/source/install-ihpc-apps.rst
@@ -156,7 +156,6 @@ interactive apps that are currently deployed at OSC and other contributing insti
      - https://github.com/OSC/bc_osc_codeserver 
      - no
      - rnode
-     -
    * - EESSI_APP
      - doitnow
      - https://github.com/doitnowgroup/openondemand-app-collection/tree/main/EESSI_APP

--- a/source/install-passenger-apps.rst
+++ b/source/install-passenger-apps.rst
@@ -11,8 +11,10 @@ https://discourse.openondemand.org.
 In order to submit the code of an passenger app that you developed to the GitHub repository, it should be available on the developer’s GitHub and 
 well commented. The comments need to include, but not limited to, mentioning if there are parts of the app that are site-specific. Also, the 
 following files must be included:
-  - **LICENSE** – an open source license (MIT License is used by Open OnDemand if unsure).
-  - **README.md** – detailing dependencies and cluster-specific instructions.
+
+- LICENSE file - the license should be open source. If you are not sure what to choose, OnDemand uses MIT License.
+
+- README.md file - which specifies all the dependencies as well as cluster specific instructions
 
 .. list-table:: Community Passenger Apps
    :header-rows: 1

--- a/source/install-passenger-apps.rst
+++ b/source/install-passenger-apps.rst
@@ -1,0 +1,29 @@
+.. _install-passenger-apps:
+
+Install Passenger Apps
+=======================
+
+This page lists community-developed **Open OnDemand Passenger Apps** that are available for installation.
+
+If you have developed your own Passenger App and would like to contribute it to the community, please post a description and link to your app on  
+https://discourse.openondemand.org.
+
+In order to submit the code of an passenger app that you developed to the GitHub repository, it should be available on the developer’s GitHub and 
+well commented. The comments need to include, but not limited to, mentioning if there are parts of the app that are site-specific. Also, the 
+following files must be included:
+  - **LICENSE** – an open source license (MIT License is used by Open OnDemand if unsure).
+  - **README.md** – detailing dependencies and cluster-specific instructions.
+
+.. list-table:: Community Passenger Apps
+   :header-rows: 1
+
+   * - Name
+     - Institution
+     - GitHub URL
+   * - EESSI_APP
+     - doitnow
+     - https://github.com/doitnowgroup/openondemand-app-collection/tree/main/EESSI_APP
+   * - EESSI_application_list
+     - doitnow
+     - https://github.com/doitnowgroup/openondemand-app-collection/tree/main/EESSI_application_list
+

--- a/source/install-passenger-apps.rst
+++ b/source/install-passenger-apps.rst
@@ -20,9 +20,6 @@ following files must be included:
    * - Name
      - Institution
      - GitHub URL
-   * - EESSI_APP
-     - doitnow
-     - https://github.com/doitnowgroup/openondemand-app-collection/tree/main/EESSI_APP
    * - EESSI_application_list
      - doitnow
      - https://github.com/doitnowgroup/openondemand-app-collection/tree/main/EESSI_application_list

--- a/source/install-passenger-apps.rst
+++ b/source/install-passenger-apps.rst
@@ -3,7 +3,7 @@
 Install Passenger Apps
 =======================
 
-This page lists community-developed **Open OnDemand Passenger Apps** that are available for installation.
+This page lists community-developed Open OnDemand Passenger Apps that are available for installation.
 
 If you have developed your own Passenger App and would like to contribute it to the community, please post a description and link to your app on  
 https://discourse.openondemand.org.


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/latest/install-ihpc-apps.html

This PR adds a new documentation page (`install-passenger-apps.rst`)
for listing community-developed Open OnDemand Passenger Apps.

It follows the structure of `install-ihpc-apps.rst` and can be
extended by contributors to include their own Passenger Apps.

Also added doitnow EESSI_APP in `install-ihpc-apps.rst`
