### PR TITLE
Add Bootstrap info

### DIFF
--- a/source/customizations/overriding-partials.inc
+++ b/source/customizations/overriding-partials.inc
@@ -34,10 +34,10 @@ distributed by the Open OnDemand package.
 
 .. code-block:: html
 
-  <div class="text-center p-4 my-3" >
+  <div class="text-center p-4 my-3 fs-5" >
     My center's custom footer.
   <div>
 
-The [utility classes](https://getbootstrap.com/docs/5.0/utilities/spacing/) for text alignment, padding, and margin in the sample are from Bootstrap, the front-end framework used in Open OnDemand. Using Bootstrap classes in custom overrides, widgets, and pages streamlines development and maintains a consistent user experience. The current installed version is Bootstrap 5.3.
+The [utility classes](https://getbootstrap.com/docs/5.0/utilities/spacing/) for text alignment, padding, margin, and font size in the sample are from Bootstrap, the front-end framework used in Open OnDemand. Using Bootstrap classes in custom overrides, widgets, and pages streamlines development and maintains a consistent user experience. The current installed version is Bootstrap 5.3.
 
 .. _dashboard's views folder: https://github.com/OSC/ondemand/tree/master/apps/dashboard/app/views

--- a/source/customizations/overriding-partials.inc
+++ b/source/customizations/overriding-partials.inc
@@ -34,8 +34,10 @@ distributed by the Open OnDemand package.
 
 .. code-block:: html
 
-  <div class="text-center h-5 my-3" >
+  <div class="text-center p-4 my-3" >
     My center's custom footer.
   <div>
+
+The [utility classes](https://getbootstrap.com/docs/5.0/utilities/spacing/) for text alignment, padding, and margin in the sample are from Bootstrap, the front-end framework used in Open OnDemand. Using Bootstrap classes in custom overrides, widgets, and pages streamlines development and maintains a consistent user experience. The current installed version is Bootstrap 5.3.
 
 .. _dashboard's views folder: https://github.com/OSC/ondemand/tree/master/apps/dashboard/app/views


### PR DESCRIPTION
https://osc.github.io/ood-documentation/latest/customizations.html#overriding-pages

I had to dig to find the Bootstrap version because it's not documented, so this is an attempt to fix that for future readers.

It's worth explicitly telling people what Bootstrap is and that it is built into OOD, if only to improve the search results.

Currently, a search for 'Bootstrap' in the docs produces outdated release notes that reference previous versions of Bootstrap, and an unexplained reference to Bootstrap alerts in https://osc.github.io/ood-documentation/latest/customizations.html#announcements. Users should be able to get better information for that search.

I'm not claiming that my text is perfect; please wordsmith as needed.

Thanks!
Sara