### PR TITLE
Add data help documentation

### DIFF
--- a/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
+++ b/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
@@ -193,34 +193,27 @@ form element based on the selected option in a select widget.
 
 .. code-block:: yaml
 
-  attributes:
-    group:
-      widget: 'select'
-      label: Membership group
-      help: 'you can find your group in your personal page'
-      options:
-        - ['First',  data-help-hard-choice: 'Choose Anything']
-        - ['Second', data-help-hard-choice: 'Choose No']
-        - ['Third',  data-help-hard-choice: 'Choose Yes']
-    hard_choice:
-      widget: 'radio_button'
-      label: 'Make your choice'
-      options:
-        - ["Yes",   "1"]
-        - ["No",    "0"]
-        - ["Maybe", "i"]
+form:
+  - node_type
+attributes:
+  node_type:
+    widget: select
+    label: Node Type
+    options:
+      - [ 'Small',  'small',  data-help-node-type: 'Small machines have 10 cores and 100 GB of RAM' ]
+      - [ 'Medium', 'medium', data-help-node-type: 'Medium machines have 50 cores and 500 GB of RAM' ]
+      - [ 'Large',  'large',  data-help-node-type: 'Large machines have 100 cores and 1 TB of RAM' ]
 
-In this case, the ``hard_choice`` radio button begins with help text reading 'Choose Anything' since 
-'First' is the default value of the ``group`` select. Choosing 'Second' or 'Third' from the group 
-select will change the help text of the ``hard_choice`` radio button to nudge the user one way or
-the other. If they choose 'First' again, it changes back to 'Choose Anything'.
+In this case, the ``node_type`` form item begins with the help text 'Small machines ...', since this
+is the initial value of the select. As you select different options, the help text changes to provide
+details of the different choices. While we have the ``node-type`` select changing its own help text in 
+this example, you can modify the help text of any form item using the same ``data-help-attribute-name``
+syntax.
 
-Note that ``data-help`` directives will override the help text provided in the attribute definition, and like 
-``data-label``, any options that do not have a ``data-help`` directive will not change the help text from it's 
-last value. This means that if we moved the 'Choose Anything' help text to the definition of ``hard_choice``,
-and left the ``First`` option without a directive, we would see the same 'Choose Anything' help text at the 
-start, but if you selected 'Second' and switch back to 'First', the help text will still read 'Choose No'.
-
+Note that ``data-help`` directives will override the help text provided in the attribute definition, and 
+any options that do not have a ``data-help`` directive will not change the help text from it's last value. 
+This means that if we left out the data-help directive on the medium option, the help text will retain its 
+previous value (either 'Small machines...' or 'Large machines...') when medium is selected instead of clearing.
 
 Dynamic Min and Maxes
 *********************

--- a/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
+++ b/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
@@ -193,16 +193,16 @@ form element based on the selected option in a select widget.
 
 .. code-block:: yaml
 
-form:
-  - node_type
-attributes:
-  node_type:
-    widget: select
-    label: Node Type
-    options:
-      - [ 'Small',  'small',  data-help-node-type: 'Small machines have 10 cores and 100 GB of RAM' ]
-      - [ 'Medium', 'medium', data-help-node-type: 'Medium machines have 50 cores and 500 GB of RAM' ]
-      - [ 'Large',  'large',  data-help-node-type: 'Large machines have 100 cores and 1 TB of RAM' ]
+  form:
+    - node_type
+  attributes:
+    node_type:
+      widget: select
+      label: Node Type
+      options:
+        - [ 'Small',  'small',  data-help-node-type: 'Small machines have 10 cores and 100 GB of RAM' ]
+        - [ 'Medium', 'medium', data-help-node-type: 'Medium machines have 50 cores and 500 GB of RAM' ]
+        - [ 'Large',  'large',  data-help-node-type: 'Large machines have 100 cores and 1 TB of RAM' ]
 
 In this case, the ``node_type`` form item begins with the help text 'Small machines ...', since this
 is the initial value of the select. As you select different options, the help text changes to provide

--- a/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
+++ b/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
@@ -180,7 +180,46 @@ form element based on the selected option in a select widget.
       value: 1
 
 In this case, selecting Node Type 'small' will change the label of Cores to
-'Number of Cores (1-4)'.
+'Number of Cores (1-4)'. Note that options without directives will leave the
+label unchanged from it's last value, and will not restore the default label.
+
+.. _dynamic-bc-apps-data-help:
+
+Dynamic Help Text
+*****************
+
+The ``data-help-*`` directive allows you to change the help text of another
+form element based on the selected option in a select widget.
+
+.. code-block:: yaml
+  attributes:
+    group:
+      widget: 'select'
+      label: Membership group
+      help: 'you can find your group in your personal page'
+      options:
+        - ['First',  data-help-hard-choice: 'Choose Anything']
+        - ['Second', data-help-hard-choice: 'Choose No']
+        - ['Third',  data-help-hard-choice: 'Choose Yes']
+    hard_choice:
+      widget: 'radio_button'
+      label: 'Make your choice'
+      options:
+        - ["Yes",   "1"]
+        - ["No",    "0"]
+        - ["Maybe", "i"]
+
+In this case, the ``hard_choice`` radio button begins with help text reading 'Choose Anything' since 
+'First' is the default value of the ``group`` select. Choosing 'Second' or 'Third' from the group 
+select will change the help text of the ``hard_choice`` radio button to nudge the user one way or
+the other. If they choose 'First' again, it changes back to 'Choose Anything'.
+
+Note that ``data-help`` directives will override the help text provided in the attribute definition, and like 
+``data-label``, any options that do not have a ``data-help`` directive will not change the help text from it's 
+last value. This means that if we moved the 'Choose Anything' help text to the definition of ``hard_choice``,
+and left the ``First`` option without a directive, we would see the same 'Choose Anything' help text at the 
+start, but if you selected 'Second' and switch back to 'First', the help text will still read 'Choose No'.
+
 
 Dynamic Min and Maxes
 *********************

--- a/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
+++ b/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
@@ -180,8 +180,8 @@ form element based on the selected option in a select widget.
       value: 1
 
 In this case, selecting Node Type 'small' will change the label of Cores to
-'Number of Cores (1-4)'. Note that options without directives will leave the
-label unchanged from it's last value, and will not restore the default label.
+'Number of Cores (1-4)'. Note that you must define a ``data-label`` directive
+on each option of the select, as it does not keep a default value.
 
 .. _dynamic-bc-apps-data-help:
 

--- a/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
+++ b/source/how-tos/app-development/interactive/dynamic-form-widgets.rst
@@ -192,6 +192,7 @@ The ``data-help-*`` directive allows you to change the help text of another
 form element based on the selected option in a select widget.
 
 .. code-block:: yaml
+
   attributes:
     group:
       widget: 'select'

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -58,7 +58,7 @@ the help text below form items when certain select options are chosen. For examp
 you may have a ``node_type`` select widget, where type ``basic`` has older GPUs than 
 ``advanced``. The ``data-help`` directive can change the help text on the ``num_gpus`` 
 option for users who select ``advanced`` so that they can take that info into account
-when deciding how many gpus to select. For full documentation, see :ref: `dynamic-bc-apps-data-help`.
+when deciding how many GPUs to select. For full documentation, see :ref: `dynamic-bc-apps-data-help`.
 
 
 Files, Projects, and Data Management

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -50,6 +50,17 @@ Forms, Widgets, and User Input
 * Smart attributes
 * Form YAML stuff
 
+New data-help Directive
+.......................
+
+Version 4.1 adds the ``data-help`` directive, allowing you to dynamically change
+the help text below form items when certain select options are chosen. For example, 
+you may have a ``node_type`` select widget, where type ``basic`` has older GPUs than 
+``advanced``. The ``data-help`` directive can change the help text on the ``num_gpus`` 
+option for users who select ``advanced`` so that they can take that info into account
+when deciding how many gpus to select. For full documentation, see :ref: `dynamic-bc-apps-data-help`.
+
+
 Files, Projects, and Data Management
 ------------------------------------
 * Files App


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/add-data-help-1214/

Fixes #1214 both in the release notes and in the standard docs. Also adds a line to data-label mentioning it's unset behavior. 

I would appreciate any opinions on these changes, as it is a bit of a test run for the rest of the sections I will complete. The main point I am still unsure about is that I used my existing test form, which has unrealistic but semantically rich attributes and options. Should we prefer using realistic values or does this seem more helpful?