### PR TITLE
Fix wording in data-label directive description

### DIFF
--- a/source/release-notes/v4.0-release-notes.rst
+++ b/source/release-notes/v4.0-release-notes.rst
@@ -231,8 +231,8 @@ New data-label Directive
 ........................
 
 Version 4.0 adds the ``data-label`` directive.  This is used to update
-the help text on a given form when certain choices are made. An example of
-this may be a ``node_type`` select widget that can change its help text based
+the label text on a given form when certain choices are made. An example of
+this may be a ``node_type`` select widget whose label changes depending
 on which node type the user has selected.
 
 :ref:`dynamic-bc-apps-data-label` is the complete documentation for this


### PR DESCRIPTION
Corrected wording in the description of the data-label directive to clarify that it updates the label text based on user choices.

Found this while writing #1214, which is the directive that actually changes the help text.
