### PR TITLE
Update v4.1 release notes with localization details

### DIFF
--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -37,7 +37,7 @@ Accessibility and Usability
 * Any UX or UI stuff
 * Accessibility improvements
 
-Open OnDemand v4.1 will be the first to include Canadian internationalizations in both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalizations for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default.
+Open OnDemand v4.1 will be the first to include Canadian internationalization files for both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalization files for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default.
 
 Interactive Jobs and Applications
 ---------------------------------

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -37,7 +37,7 @@ Accessibility and Usability
 * Any UX or UI stuff
 * Accessibility improvements
 
-Open OnDemand v4.1 will be the first to include Canadian internationalization files for both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalization files for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default. In addition to making it easier for others in your country or region to use Open OnDemand, contributed localizations will also be automatically updated with new releases.
+Open OnDemand v4.1 will be the first to include Canadian internationalization files for both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalization files for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default. In addition to making it easier for others in your country or region to use Open OnDemand, contributed localization files will also be automatically updated with new releases.
 
 Interactive Jobs and Applications
 ---------------------------------

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -37,7 +37,7 @@ Accessibility and Usability
 * Any UX or UI stuff
 * Accessibility improvements
 
-Open OnDemand v4.1 will be the first to include Canadian internationalizations in both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalizations for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files` <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default.
+Open OnDemand v4.1 will be the first to include Canadian internationalizations in both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalizations for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default.
 
 Interactive Jobs and Applications
 ---------------------------------

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -37,7 +37,17 @@ Accessibility and Usability
 * Any UX or UI stuff
 * Accessibility improvements
 
-Open OnDemand v4.1 will be the first to include Canadian internationalization files for both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalization files for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default. In addition to making it easier for others in your country or region to use Open OnDemand, contributed localization files will also be automatically updated with new releases.
+New Canadian Internationalization Files
+.......................................
+
+Open OnDemand v4.1 will be the first to include Canadian internationalization 
+files for both English and French, thanks to Rahim Khoja of the University of 
+Alberta. This adds to pre-existing internationalization files for American 
+English, Chinese, and Japanese. It is easy to :ref:`customize or generate your 
+own localization files <customization_localization>`, and we greatly appreciate 
+community contributions for languages we do not include by default. In addition 
+to making it easier for others in your country or region to use Open OnDemand, 
+contributed localization files will also be automatically updated with new releases.
 
 Interactive Jobs and Applications
 ---------------------------------

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -37,7 +37,7 @@ Accessibility and Usability
 * Any UX or UI stuff
 * Accessibility improvements
 
-Open OnDemand v4.1 will be the first to include Canadian internationalization files for both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalization files for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default.
+Open OnDemand v4.1 will be the first to include Canadian internationalization files for both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalization files for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default. In addition to making it easier for others in your country or region to use Open OnDemand, contributed localizations will also be automatically updated with new releases.
 
 Interactive Jobs and Applications
 ---------------------------------

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -37,6 +37,8 @@ Accessibility and Usability
 * Any UX or UI stuff
 * Accessibility improvements
 
+Open OnDemand v4.1 will be the first to include Canadian internationalizations in both English and French, thanks to Rahim Khoja of the University of Alberta. This adds to pre-existing internationalizations for American English, Chinese, and Japanese. It is easy to :ref:`customize or generate your own localization files` <customization_localization>`, and we greatly appreciate community contributions for languages we do not include by default.
+
 Interactive Jobs and Applications
 ---------------------------------
 * Batch Connect

--- a/source/spelling_wordlist.txt
+++ b/source/spelling_wordlist.txt
@@ -154,6 +154,8 @@ Guilherme
 Maluf
 Balzana
 Buechler
+Rahim
+Khoja
 Pitzer
 Bubblewrap
 codebase


### PR DESCRIPTION
Fixes #1236. Added information to release notes about Canadian internationalizations in v4.1, and updated localization docs to use realistic example files (en-US.yml instead of en.yml)

https://osc.github.io/ood-documentation-test/add-canadian-locales-notes-1236/
