### PR TITLE
add shell term notes

### DIFF
--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -32,6 +32,15 @@ Platform Configuration, Operations, and Observability
 * Environment variables
 * Portal stuff
 
+Shell Terminal is Now Configurable
+..................................
+
+The new ``OOD_SHELL_TERM`` environment variable allows the default ``TERM=xterm-16color`` 
+to be overridden. This variable can be set to any other terminal type whose escape codes are 
+fully supported by the underlying `hterm library <https://chromium.googlesource.com/apps/libapps/+/HEAD/hterm/docs/ControlSequences.md>`__.
+Some other common supported options include ``xterm``, ``xterm-256color``, and ``xterm-direct``.
+This environment variable can only be set from ``/etc/ood/config/apps/shell/env``.
+
 Accessibility and Usability
 ---------------------------
 * Any UX or UI stuff


### PR DESCRIPTION
Fixes #1243. Adds a release note item describing the new config. Does not edit the main docs because this was already done in #1165 
