### PR TITLE
Add file download limit notes

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -463,20 +463,33 @@ If you want to disable file upload altogether, set ``FILE_UPLOAD_MAX`` to 0 and 
 the ``nginx_file_upload_max`` configuration alone (or comment it out so the default
 is used).
 
+.. _set_download_limits:
+
 Set Download Limits
 -------------------
 
-By default, the maximum file download size is 10.7 GB (10737418240 bytes). 
-If you wish to change this, you can set the ``OOD_DOWNLOAD_DIR_MAX`` configuration environment 
-variable in the ``/etc/ood/config/apps/dashboard/env`` file to the desired value in bytes.
+By default, the maximum download size for files and directories is 10.7 GB (10737418240 bytes). 
+If you wish to change this, you can set the ``OOD_DOWNLOAD_DIR_MAX`` and/or ``OOD_DOWNLOAD_FILE_MAX`` 
+configuration environment variables in the ``/etc/ood/config/apps/dashboard/env`` file to the desired
+value for directories and files, respectively. Both variables can also be set in your :ref:`ondemand-d-ymls`
+file as ``download_dir_max`` and ``download_file_max``.
 
-For example, to set the limit to 5 GB, you can add the following line to the ``/etc/ood/config/apps/dashboard/env`` file:
+For example, to set the directory limit to 8 GiB and the file limit to 5 GiB, you can add the following 
+lines to the ``/etc/ood/config/apps/dashboard/env`` file:
 
 .. code-block:: 
 
-  OOD_DOWNLOAD_DIR_MAX=5368709120
+  OOD_DOWNLOAD_DIR_MAX=8589934592
+  OOD_DOWNLOAD_FILE_MAX=5368709120
 
-Note that this will limit the download size for all users of the Open OnDemand instance.
+Note that this will limit the download size for all users of the Open OnDemand instance. If you want 
+to set it as part of your :ref:`profiles_guide` to affect only a subset of users, you can add the
+the following lines to a specific profile in your :ref:`ondemand-d-ymls`.
+
+.. code-block::
+
+  download_dir_max:8589934592
+  download_file_max:5368709120
 
 .. warning::
    This configuration value is expected to be numbers only (no characters)

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -160,14 +160,25 @@ to open and view HTML files directly. This is disabled by default due to securit
 concerns, but can be enabled by setting ``OOD_UNSAFE_RENDER_HTML=true`` in your 
 environment or including ``unsafe_render_html=true`` in your :ref:`ondemand-d-ymls`.
 
+File Downloads Have a Maximum Size
+..................................
+
+Version 4.1 adds a configurable maximum size for file downloads, which also applies to 
+opening files in the file browser. This can be configured with the ``OOD_DOWNLOAD_FILE_MAX`` 
+environment variable, or setting ``download_file_max`` in your :ref:`ondemand-d-ymls`. 
+This variable accepts plain integer values, and defaults to 10GiB. Note that size 
+configurations always accept an integer number of (binary) bytes, so the default 10GiB 
+would be represented as ``10737418240``. For more details on this configuration, as well 
+as a similar one for directory downloads, see :ref:`set_download_limits`.
 
 File Editor Has a Maximum Size
 ..............................
 
-As of v4.1 the file editor will not open files above a configurable maximum size. The default is 12MB,
+As of v4.1 the file editor will not open files above a configurable maximum size. The default is 12MiB,
 but this can be changed by setting the ``OOD_FILE_EDITOR_MAX_SIZE`` environment variable, or setting 
-``file_editor_max_size`` in your :ref:`ondemand-d-ymls`. Note that size configurations always accept an integer
-number of (binary) bytes, so the 12MB default would be represented as ``12582912``.
+``file_editor_max_size`` in your :ref:`ondemand-d-ymls`. This uses the same binary byte format as 
+``OOD_DOWNLOAD_FILE_MAX`` above, so the 12MiB default would be represented as ``12582912``.
+
 
 
 Help, Support and Institutional Integration

--- a/source/spelling_wordlist.txt
+++ b/source/spelling_wordlist.txt
@@ -72,6 +72,7 @@ Gemfile
 noVNC
 walltime
 Walltimes
+MiB
 GiB
 prepopulate
 dismissible


### PR DESCRIPTION
Fixes #1230. Adds file download max notes and updates the section on 'Set Download Limits' to include file download limits and (new) configuration profile support
