### PR TITLE
Add dynamic form announcement notes

### DIFF
--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -69,6 +69,13 @@ Accessibility and Usability
 * Any UX or UI stuff
 * Accessibility improvements
 
+Dynamic Forms Announce to Screen Readers
+........................................
+
+Dynamic batch connect forms now alert screen readers when form items are changed, 
+allowing visually impaired users to better understand what is happening on the page.
+This is supported by all :ref:`dynamic form actions <dynamic-bc-apps>`.
+
 New Dashboard Widgets
 .....................
 


### PR DESCRIPTION
Fixes #1220. Adds a release note item for dynamic form actions. Does not update the dynamic form docs themselves. Confirmed that this is in fact supported by all dynamic form actions.
