### PR TITLE
Add note for Passenger telemetry

### DIFF
--- a/source/reference/files/nginx-stage-yml.rst
+++ b/source/reference/files/nginx-stage-yml.rst
@@ -346,6 +346,8 @@ Configuration Options
 
       passenger_log_file: '/some/other/location/%{user}/error.log'
 
+.. _passenger_options:
+
 .. describe:: passenger_options (Hash)
 
    A Hash of additional Passenger options

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -55,6 +55,14 @@ Platform Configuration, Operations, and Observability
 * Environment variables
 * Portal stuff
 
+Passenger Telemetry Now Disabled By Default
+...........................................
+
+`Passenger anonymous telemetry <https://www.phusionpassenger.com/docs/advanced_guides/in_depth/ruby/anonymous_telemetry_reporting.html>`__
+is now disabled by default in version 4.1. If you would like to override this default 
+and enable passenger telemetry, you can add ``passenger_disable_anonymous_telemetry: 'off'``
+to your :ref:`passenger_options hash <passenger_options>`.
+
 Shell Terminal is Now Configurable
 ..................................
 


### PR DESCRIPTION
Fixes #1237. Adds a release note item linking to both the passenger guides on telemetry and the `passenger_options` hash where this can be changed.
