### PR TITLE
Add form item header note

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -676,6 +676,50 @@ are:
 
           display: true
 
+.. _item_header_option:
+
+.. describe:: header (String, null)
+     
+     Optional markdown header above the item's label that does not respond to dynamic actions on the item.
+
+     Default
+       No header is displayed.
+       
+       .. code-block:: yaml
+
+          header: null
+        
+     Example
+       Display a header to mark a section in the form.
+       
+       .. code-block:: yaml
+
+          header: |
+            ## Account and Queue Settings
+            - Accounts starting with `P` have access to priority queues.
+            - Priority queues lower wait times, but increase charge rates.
+
+.. describe:: hide_by_default (Boolean, false)
+
+     Determines whether the form item is initially shown in the form. If this is set
+     to ``true``, the form item will not be shown until a :ref:`data-hide action <dynamic-bc-apps-data-hide>`
+     reveals it.
+
+     Default
+       False. The form item will be shown until a data-hide action hides it.
+
+       .. code-block:: yaml
+            
+            hide_by_default: false
+
+     Example
+       Hide the form item on page load, since it is not needed unless a specific option is selected.
+
+       .. code-block:: yaml
+
+            hide_by_default: true
+
+
 Examples
 --------
 

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -176,6 +176,14 @@ certain items are only needed for a few options, as you no longer have to includ
 on all of those options, but instead only supply directives to options that will show the item.
 For full documentation, see the :ref:`dynamic-bc-apps-data-hide`
 
+Form Items Accept Markdown Headers
+..................................
+
+Batch connect form items accept a ``header`` attribute, which can be used to render 
+markdown above the item's label. Headers can provide useful structure to forms, and 
+are not affected when the item is hidden, or by any other dynamic form actions. For 
+full documentation, see :ref:`Form Item Headers <item_header_option>`.
+
 Files, Projects, and Data Management
 ------------------------------------
 * Files App


### PR DESCRIPTION
Fixes #1221. Adds a release note for form item headers, and updates the custom attribute options list with full information and example.

Also adds the hide_by_default option to the list of custom attribute options