### PR TITLE
Add python helper methods and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,56 @@ There are two ways to build the documentation.
    package to use by python.org for dependency
    management](https://packaging.python.org/tutorials/managing-dependencies/)
 
-### Default - Docker/Podman
+### Default - Docker/Podman Container
 
 Currently all builds are generated using the
 [ood-documentation-build](https://github.com/OSC/ood-documentation-build/)
-container image. They are built using the following command from the root of this repo:
+container image. To use the helper methods provided below, you will have to
+have either ruby or python installed on your machine. All helper commands 
+should be run from the root of the repository.
 
-Note that because we're using `rake`, you'll need to have `ruby` installed on your
-system as well as the `rake` gem.
+#### Ruby
+The ruby helpers use `rake`, so you'll need to have `ruby` installed on your
+system as well as the `rake` gem. Then you can run
 
 ```bash
 rake build
+```
+to generate HTML from the local source files,
+
+```bash
+rake open
+```
+to open the HTML with your browser, and
+
+```bash
+rake spellcheck
+```
+
+to check spelling. Note that spellchecking is automatically executed on all pull requests.
+
+And you can run `rake` without arguments to see each of these tasks in the CLI.
+
+#### Python
+The python helpers use the `tasks.py` file, and only require `python` to be installed.
+
+The python commands have the same functions as the ruby ones above, but use the following syntax
+
+```bash
+python ./tasks.py build
+```
+
+```bash
+python ./tasks.py open
+```
+
+```bash
+python ./tasks.py spellcheck
+```
+
+And you can list these commands in the CLI with
+```bash
+python tasks.py --help
 ```
 
 ### Make with Pip/python

--- a/tasks.py
+++ b/tasks.py
@@ -35,20 +35,6 @@ def podman_available() -> bool:
     return exists("podman")
 
 
-def user_group() -> str:
-    """Return current user's uid:gid for non-Windows to mirror Rakefile behavior."""
-    if is_windows():
-        return ""
-    try:
-        import os as _os
-
-        uid = _os.getuid()
-        gid = _os.getgid()
-        return f"{uid}:{gid}"
-    except Exception:
-        return ""
-
-
 def run_cmd() -> list:
     """Compose the container runtime command list analogous to Rakefile's run_cmd."""
     mount_arg = f"{PROJECT_DIR}:/doc"
@@ -72,10 +58,6 @@ def run_cmd() -> list:
             "-v",
             mount_arg,
         ]
-        if not is_windows():
-            ug = user_group()
-            if ug:
-                cmd.extend(["-u", ug])
         cmd.append(IMAGE)
         return cmd
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+# Usage examples:
+#   python tasks.py --help
+#   python tasks.py build
+#   python tasks.py spellcheck
+#   python tasks.py open
+
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+IMAGE = "ohiosupercomputer/ood-doc-build:v3.1.0"
+PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def is_windows() -> bool:
+    return platform.system().lower().startswith("win")
+
+
+def exists(program: str) -> bool:
+    # Cross-platform check if a program exists in PATH
+    return shutil.which(program) is not None
+
+
+def docker_available() -> bool:
+    return exists("docker")
+
+
+def podman_available() -> bool:
+    return exists("podman")
+
+
+def user_group() -> str:
+    """Return current user's uid:gid for non-Windows to mirror Rakefile behavior."""
+    if is_windows():
+        return ""
+    try:
+        import os as _os
+
+        uid = _os.getuid()
+        gid = _os.getgid()
+        return f"{uid}:{gid}"
+    except Exception:
+        return ""
+
+
+def run_cmd() -> list:
+    """Compose the container runtime command list analogous to Rakefile's run_cmd."""
+    mount_arg = f"{PROJECT_DIR}:/doc"
+
+    if podman_available():
+        return [
+            "podman",
+            "run",
+            "--rm",
+            "-it",
+            "-v",
+            mount_arg,
+            IMAGE,
+        ]
+    if docker_available():
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            "-v",
+            mount_arg,
+        ]
+        if not is_windows():
+            ug = user_group()
+            if ug:
+                cmd.extend(["-u", ug])
+        cmd.append(IMAGE)
+        return cmd
+
+    raise RuntimeError(
+        "Cannot find any suitable container runtime to build. Need 'podman' or 'docker' installed."
+    )
+
+
+def _print_and_exec(full_cmd: list) -> int:
+    print(" ".join(full_cmd))
+    proc = subprocess.Popen(full_cmd)
+    proc.wait()
+    return proc.returncode
+
+
+def cmd_build(_args) -> int:
+    """Build docs using container (docker/podman)."""
+    try:
+        cmd = run_cmd() + [
+            "make",
+            "html",
+        ]
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    return _print_and_exec(cmd)
+
+
+def cmd_spellcheck(_args) -> int:
+    """Spellcheck documentation using container (docker/podman)."""
+    try:
+        cmd = run_cmd() + [
+            "make",
+            "spellcheck",
+        ]
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    return _print_and_exec(cmd)
+
+
+def cmd_open(_args) -> int:
+    """Open built documentation in browser."""
+    index_path = os.path.join(PROJECT_DIR, "build", "html", "index.html")
+    if is_windows():
+        try:
+            os.startfile(index_path)  # type: ignore[attr-defined]
+            return 0
+        except OSError as e:
+            print(f"Failed to open {index_path}: {e}", file=sys.stderr)
+            return 1
+
+    if shutil.which("xdg-open"):
+        return subprocess.call(["xdg-open", index_path])
+    if shutil.which("open"):
+        return subprocess.call(["open", index_path])
+
+    print(
+        "Could not find a suitable opener (xdg-open/open). Open this file manually: "
+        + index_path,
+        file=sys.stderr,
+    )
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Tasks for building and managing documentation",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    p_build = sub.add_parser("build", help="Build documentation using container")
+    p_build.set_defaults(func=cmd_build)
+
+    p_spell = sub.add_parser("spellcheck", help="Spellcheck documentation using container")
+    p_spell.set_defaults(func=cmd_spellcheck)
+
+    p_open = sub.add_parser("open", help="Open built documentation HTML in browser")
+    p_open.set_defaults(func=cmd_open)
+
+    return parser
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # Default behavior similar to Rakefile default task: show available tasks
+    if not getattr(args, "command", None):
+        parser.print_help()
+        return 0
+
+    func = getattr(args, "func", None)
+    if func is None:
+        parser.print_help()
+        return 2
+
+    return int(func(args) or 0)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
From the user guide committee, it was clear that the community would appreciate being able to build the docs with python, as many people already have python installed but do not have ruby. This translates the functionality from the `Rakefile` (except uids) into python syntax. 

People were also a bit unclear on the commands, so I also added a bit more detail into the three supported commands, in addition to documenting the new python ones, in the README.

These changes do not affect any published docs page.
