### PR TITLE
Add note for path select title 1226

### DIFF
--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -184,6 +184,13 @@ markdown above the item's label. Headers can provide useful structure to forms, 
 are not affected when the item is hidden, or by any other dynamic form actions. For 
 full documentation, see :ref:`Form Item Headers <item_header_option>`.
 
+Path Selectors Accept Custom Titles
+...................................
+
+The title on the path selector modal is now customizable, allowing you to accurately
+represent what the selected path will be used for. For more details, see the 
+:ref:`full path selector documentation <path_selector>`.
+
 Recently Used Apps Display Recent Settings
 ..........................................
 


### PR DESCRIPTION
Fixes #1226. Adds a release note item for path selector `popup_title` attribute, does not update the docs as this was already done in #1143.
