### PR TITLE
Add global bc items note 1224

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -992,5 +992,18 @@ of the file and it will display the select widget defined above.
   form:
     - global_queues
 
+As of version 4.1, you can use these global items to override predefined attributes in the form. This is done
+by specifying the attribute name prefixed with ``global_`` under your ``global_bc_form_items`` key, and only
+defining the options that you would like to override. For example, you could override ``bc_num_hours`` to
+have a maximum value of 100 using the following code in your ``ondemand.d`` file.
+
+.. code-block:: yaml
+
+  # /etc/ood/config/ondemand.d/global_bc_items.yml
+
+  global_bc_form_items:
+    global_bc_num_hours:
+      max: 100
+
 .. _markdown: https://en.wikipedia.org/wiki/Markdown
 .. _html form: https://en.wikipedia.org/wiki/Form_(HTML)

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -157,6 +157,14 @@ Open OnDemand now offers the ``auto_cores`` smart attribute, which allows you to
 When used alongside the ``auto_batch_cluster`` attribute, this ensures that the number of cores selected is valid
 for the cluster you are submitting to. For more details, see :ref:`auto_batch_clusters` and :ref:`auto_cores`.
 
+Global Batch Connect Items Can Override Predefined Attributes
+.............................................................
+
+It is now possible to modify the :ref:`predefined attributes <app-development-interactive-form-predefined-attributes>`
+using global definitions. This works similarly to other :ref:`global_bc_form_items`, except that the attribute name
+must be the predefined attribute name prefixed with ``global_``, and you only have to define attributes you want to change.
+See the full section on :ref:`global_bc_form_items` for more details.
+
 New data-help Directive
 .......................
 


### PR DESCRIPTION
Fixes #1224. Adds a release note for overriding predefined attributes with global items, and updates the docs on global items for the same
