### PR TITLE
Add note for session card announcements

### DIFF
--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -78,12 +78,14 @@ Accessibility and Usability
 * Any UX or UI stuff
 * Accessibility improvements
 
-Dynamic Forms Announce to Screen Readers
+Dynamic Forms and Session Cards Announce to Screen Readers
 ........................................
 
 Dynamic batch connect forms now alert screen readers when form items are changed, 
 allowing visually impaired users to better understand what is happening on the page.
-This is supported by all :ref:`dynamic form actions <dynamic-bc-apps>`.
+This is supported by all :ref:`dynamic form actions <dynamic-bc-apps>`. Similarly,
+interactive session cards provide live announcements when job status changes between 
+queued, running, and completed.
 
 New Skip Navigation Button
 ..........................

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -79,7 +79,7 @@ Accessibility and Usability
 * Accessibility improvements
 
 Dynamic Forms and Session Cards Announce to Screen Readers
-........................................
+..........................................................
 
 Dynamic batch connect forms now alert screen readers when form items are changed, 
 allowing visually impaired users to better understand what is happening on the page.


### PR DESCRIPTION
Fixes #1271. Adds mention of session card announcements to the existing item on dynamic form announcements
