### PR TITLE
Fix typo in auto_queues documentation

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -295,7 +295,7 @@ auto_groups
 
 auto_queues
   This will generate a ``select`` widget list of all the queues available to the user.
-  These queues will be cluster if you have :ref:`dynamic options <dynamic-bc-apps>`
+  These queues will be cluster aware if you have :ref:`dynamic options <dynamic-bc-apps>`
   enabled. That is, they'll show or hide relevant lists given the currently selected
   ``cluster``.
 


### PR DESCRIPTION
Adds missing 'aware'