### PR TITLE
add docs on :lower for lowercasing user_map_match

### DIFF
--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -406,8 +406,8 @@ Configure General Options
    In addition to lua patterns, you can append ``:lower`` to the pattern to
    automatically lowercase the matched string. An example configuration may be
    something like ``.*:lower`` to match anything then lowercase it or
-   ``^([^@]+)@example.edu$:lower`` to match the email addres with the domain
-   example.edu then lowercase it.
+   ``^([^@]+)@example.edu$:lower`` to match the email address with the domain
+   ``example.edu`` then lowercase it.
 
 
    Default

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -403,6 +403,13 @@ Configure General Options
       > string.match('ktrout@example.edu', '^([^@]+)@example.edu$')
       ktrout
 
+   In addition to lua patterns, you can append ``:lower`` to the pattern to
+   automatically lowercase the matched string. An example configuration may be
+   something like ``.*:lower`` to match anything then lowercase it or
+   ``^([^@]+)@example.edu$:lower`` to match the email addres with the domain
+   example.edu then lowercase it.
+
+
    Default
       Match any characters 0 or more times.
 

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -46,7 +46,7 @@ Add ``ondemand_manage_config_dir`` boolean to allow OnDemand to manage ``.config
 Authentication and Security
 ---------------------------
 
-Lowercasing in user mapping
+Lower-casing in user mapping
 ...........................
 
 The :ref:`user_map_match <ood-portal-generator-user-map-match>` configuration now

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -47,7 +47,7 @@ Authentication and Security
 ---------------------------
 
 Lower-casing in user mapping
-...........................
+............................
 
 The :ref:`user_map_match <ood-portal-generator-user-map-match>` configuration now
 responds to ``:lower`` to automatically lowercase ``REMOTE_USER`` when matching

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -45,7 +45,16 @@ Add ``ondemand_manage_config_dir`` boolean to allow OnDemand to manage ``.config
 
 Authentication and Security
 ---------------------------
-* What the sysadmins care about :)
+
+Lowercasing in user mapping
+...........................
+
+The :ref:`user_map_match <ood-portal-generator-user-map-match>` configuration now
+responds to ``:lower`` to automatically lowercase ``REMOTE_USER`` when matching
+against it.
+
+See :ref:`the user_map_match documentation <ood-portal-generator-user-map-match>`
+for more details.
 
 Platform Configuration, Operations, and Observability
 -----------------------------------------------------


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/BRANCH-NAME/

Add documentation on automatically lowercasing user_map_match.

Fixes #1241
