### PR TITLE
add docs and RNs on secure_[r]node_uri config

### DIFF
--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -788,6 +788,72 @@ assets and links supplied by the web server are relative and not absolute.
 
           rnode_uri: "/rnode"
 
+.. _ood-portal-generator-configuration-secure-proxy:
+
+.. describe:: secure_node_uri (String, null)
+
+  Introduced in 4.1. Similar to ``node_uri`` above, only in that
+  it will proxy to origin servers using the https protocol instead
+  of plain text http.
+
+  Default
+    This feature is disabled by default.
+
+    .. code-block:: yaml
+
+      secure_node_uri: null
+
+  Example
+    Enable this feature.
+
+    .. code-block:: yaml
+
+      secure_node_uri: "/secure-node"
+
+.. describe:: secure_rnode_uri (String, null)
+
+
+  Introduced in 4.1. Similar to ``rnode_uri`` above, only in that it will
+  proxy to origin  servers using the https protocol instead of plain text http.
+
+  Default
+    This feature is disabled by default.
+
+    .. code-block:: yaml
+
+      secure_rnode_uri: null
+
+  Example
+    Enable this feature.
+
+    .. code-block:: yaml
+
+      secure_rnode_uri: "/secure-rnode"
+
+.. describe:: ssl_proxy (Array, [])
+
+  When enabling SSL/TLS origins above, centers may need to provide
+  apache SSL directives to successfully communicate with the origin
+  servers. Centers can use this configuration to provide such directives.
+
+  Default
+    Do not supply any ``SSLProxy`` directives.
+
+    .. code-block:: yaml
+
+      ssl_proxy: []
+
+  Example
+    Do not check the origin server's certificate CN field or name when
+    proxying to origins over https.
+
+    .. code-block:: yaml
+
+      ssl_proxy:
+        - 'SSLProxyCheckPeerCN Off'
+        - 'SSLProxyCheckPeerName Off'
+
+
 Configure per-user NGINX
 ------------------------
 

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -56,6 +56,17 @@ against it.
 See :ref:`the user_map_match documentation <ood-portal-generator-user-map-match>`
 for more details.
 
+Proxying to origins over https
+..............................
+
+4.1 introduces the ability to proxy to origin servers over https protocol.
+While continuing to support plain text origins through ``node_uri`` and
+``rnode_uri`` we've added ``secure_node_uri`` and ``secure_rnode_uri``
+configuratins in ``ood_portal.yml``.
+
+See the :ref:`ood_portal.yml configuration for secure proxies<ood-portal-generator-configuration-secure-proxy>`
+for more information.
+
 Platform Configuration, Operations, and Observability
 -----------------------------------------------------
 * NGINX

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -62,7 +62,7 @@ Proxying to origins over https
 4.1 introduces the ability to proxy to origin servers over https protocol.
 While continuing to support plain text origins through ``node_uri`` and
 ``rnode_uri`` we've added ``secure_node_uri`` and ``secure_rnode_uri``
-configuratins in ``ood_portal.yml``.
+configurations in ``ood_portal.yml``.
 
 See the :ref:`ood_portal.yml configuration for secure proxies<ood-portal-generator-configuration-secure-proxy>`
 for more information.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/secure-nodes/

Fixes #1257 by adding documentation and release notes on secure_[r]node_uri configurations.
