### PR TITLE
add 4.1 register options to release notes

### DIFF
--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -1133,7 +1133,7 @@ to ``null`` will disable this feature.
 
 .. describe:: register_path (String, register_root)
 
-  The filesystem path that the ``register_uri`` can map to.
+  The file-system path that the ``register_uri`` can map to.
 
   Default
     Same value as ``register_root`` if it's been set.

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -1078,6 +1078,8 @@ on mod_auth_openidc_.
 
 .. _mod_auth_openidc: https://github.com/zmartzone/mod_auth_openidc
 
+.. _ood-portal-generator-user-registration:
+
 Configure User Registration
 ---------------------------
 
@@ -1128,6 +1130,62 @@ to ``null`` will disable this feature.
        .. code-block:: yaml
 
           register_root: "/var/www/ood/register"
+
+.. describe:: register_path (String, register_root)
+
+  The filesystem path that the ``register_uri`` can map to.
+
+  Default
+    Same value as ``register_root`` if it's been set.
+
+    .. code-block:: yaml
+
+      register_path: '< the same value as register_root >'
+
+  Example
+    Enable it to ``/var/www/ood_register``.
+
+    .. code-block:: yaml
+
+      register_root: "/var/www/ood_register"
+
+.. describe:: register_method (String, 'Alias')
+
+  The apache method to which ``register_uri`` will map to ``register_path``.
+
+  Default
+    Use the apache directive ``Alias`` to map ``register_uri`` to ``register_path``.
+
+    .. code-block:: yaml
+
+      register_method: 'Alias'
+
+  Example
+    Use the apache directive ``ScriptAlias`` to map ``register_uri`` to ``register_path``.
+
+    .. code-block:: yaml
+
+      register_root: 'ScriptAlias'
+
+.. describe:: register_method_options (Array, null)
+
+  Additional apache directives you may need to supply to register users.
+
+  Default
+    None provided.
+
+    .. code-block:: yaml
+
+      register_method_options: null
+
+  Example
+    Provide a ``WSGIDaemonProcess`` directive with some arguments to help register users.
+
+    .. code-block:: yaml
+
+      register_method_options:
+        - 'WSGIDaemonProcess register user=www-data group=www-data threads=5 home=/var/www/flask-apps/register'
+
 
 .. describe:: oidc_provider_metadata_url (String, null)
 

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -1133,7 +1133,7 @@ to ``null`` will disable this feature.
 
 .. describe:: register_path (String, register_root)
 
-  New in 4.1. The file-system path that the ``register_uri`` can map to.
+  Added in 4.1. The file-system path that the ``register_uri`` can map to.
 
   Default
     Same value as ``register_root`` if it's been set.
@@ -1151,7 +1151,7 @@ to ``null`` will disable this feature.
 
 .. describe:: register_method (String, 'Alias')
 
-  New in 4.1. The apache method to which ``register_uri`` will map to ``register_path``.
+  Added in 4.1. The apache method to which ``register_uri`` will map to ``register_path``.
 
   Default
     Use the apache directive ``Alias`` to map ``register_uri`` to ``register_path``.
@@ -1169,7 +1169,7 @@ to ``null`` will disable this feature.
 
 .. describe:: register_method_options (Array, null)
 
-  New in 4.1. Additional apache directives you may need to supply to register users.
+  Added in 4.1. Additional apache directives you may need to supply to register users.
 
   Default
     None provided.

--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -1133,7 +1133,7 @@ to ``null`` will disable this feature.
 
 .. describe:: register_path (String, register_root)
 
-  The file-system path that the ``register_uri`` can map to.
+  New in 4.1. The file-system path that the ``register_uri`` can map to.
 
   Default
     Same value as ``register_root`` if it's been set.
@@ -1151,7 +1151,7 @@ to ``null`` will disable this feature.
 
 .. describe:: register_method (String, 'Alias')
 
-  The apache method to which ``register_uri`` will map to ``register_path``.
+  New in 4.1. The apache method to which ``register_uri`` will map to ``register_path``.
 
   Default
     Use the apache directive ``Alias`` to map ``register_uri`` to ``register_path``.
@@ -1169,7 +1169,7 @@ to ``null`` will disable this feature.
 
 .. describe:: register_method_options (Array, null)
 
-  Additional apache directives you may need to supply to register users.
+  New in 4.1. Additional apache directives you may need to supply to register users.
 
   Default
     None provided.

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -67,6 +67,14 @@ configurations in ``ood_portal.yml``.
 See the :ref:`ood_portal.yml configuration for secure proxies<ood-portal-generator-configuration-secure-proxy>`
 for more information.
 
+Expaneded Registration Options
+..............................
+
+More ``ood_portal.yml`` options for registering users have been added in 4.1.
+They are ``register_path``, ``register_method`` and ``register_method_options``.
+
+See :ref:`ood-portal-generator-user-registration` for more details.
+
 Platform Configuration, Operations, and Observability
 -----------------------------------------------------
 * NGINX

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -67,8 +67,8 @@ configurations in ``ood_portal.yml``.
 See the :ref:`ood_portal.yml configuration for secure proxies<ood-portal-generator-configuration-secure-proxy>`
 for more information.
 
-Expaneded Registration Options
-..............................
+Expanded Registration Options
+.............................
 
 More ``ood_portal.yml`` options for registering users have been added in 4.1.
 They are ``register_path``, ``register_method`` and ``register_method_options``.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/register-updates/

Fixes #1239 by adding 4.1 register options to release notes and ood_portal.yml page.
