### PR TITLE
Add Project Manager release note

### DIFF
--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -51,7 +51,7 @@ and NodeJS dependency changes listed in the next two sections.
 
 .. warning:: 
   The Job Composer is officially **deprecated** in 4.1, and will no longer receive new features or bug fixes
-  beyond critical maintenance. Although the new :ref:`Project Manager <project-manager-note>` covers and 
+  beyond critical maintenance. Although the :ref:`new Project Manager <project-manager-note>` covers and 
   surpasses all Job Composer functionality, the Job Composer will remain enabled as a legacy feature until version 5.0.
 
 Operating System Support
@@ -357,7 +357,7 @@ indentation. This is most relevant to languages that rely on consistent indentat
 and YAML. For YAML files, only soft tabs are syntactically supported. Python recommends soft tabs for new 
 projects, but will not allow mixing of hard and soft tabs within a project.
 
-.. _project-manager-note
+.. _project-manager-note:
 The Project Manager
 ...................
 

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -352,6 +352,22 @@ indentation. This is most relevant to languages that rely on consistent indentat
 and YAML. For YAML files, only soft tabs are syntactically supported. Python recommends soft tabs for new 
 projects, but will not allow mixing of hard and soft tabs within a project.
 
+The Project Manager
+...................
+
+Version 4.1 enables the Project Manager by default, a new alternative to the Job Composer that brings the
+automatic slurm interaction of batch connect forms to your personal job scripts. In addition to this core 
+functionality, it also provides support for workflows that can submit multiple dependent jobs at once, and
+easy collaboration on projects among teams. The core functionality will work without modification, but
+collaborative projects work best when used with :ref:`properly configured shared direcories <project_manager_shared_project_root>`. 
+For more details on customization and configuration of the Project Manager, see :ref:`project_manager`, or 
+see :ref:`project-manager-tutorial` for an example driven guide intended for users.
+
+.. warning::
+   The Job Composer is officially **deprecated** in 4.1, and will no longer receive new features or bug fixes
+   beyond critical maintenance. Although the Project Manager covers and surpasses all Job Composer functionality,
+   the Job Composer will remain enabled as a legacy feature until version 5.0.
+
 Help, Support and Institutional Integration
 -------------------------------------------
 

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -358,6 +358,7 @@ and YAML. For YAML files, only soft tabs are syntactically supported. Python rec
 projects, but will not allow mixing of hard and soft tabs within a project.
 
 .. _project-manager-note:
+
 The Project Manager
 ...................
 

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -49,6 +49,11 @@ Breaking Changes and Deprecations
 The only breaking changes in 4.1 are with the operating system support changes
 and NodeJS dependency changes listed in the next two sections.
 
+.. warning:: 
+  The Job Composer is officially **deprecated** in 4.1, and will no longer receive new features or bug fixes
+  beyond critical maintenance. Although the new :ref:`Project Manager <project-manager-note>` covers and 
+  surpasses all Job Composer functionality, the Job Composer will remain enabled as a legacy feature until version 5.0.
+
 Operating System Support
 ------------------------
 
@@ -352,6 +357,7 @@ indentation. This is most relevant to languages that rely on consistent indentat
 and YAML. For YAML files, only soft tabs are syntactically supported. Python recommends soft tabs for new 
 projects, but will not allow mixing of hard and soft tabs within a project.
 
+.. _project-manager-note
 The Project Manager
 ...................
 
@@ -360,13 +366,9 @@ automatic scheduler interaction of batch connect forms to your personal job scri
 functionality, it also provides support for workflows that can submit multiple dependent jobs at once, and
 easy collaboration on projects among teams. The core functionality will work without modification, but
 collaborative projects work best when used with :ref:`properly configured shared direcories <project_manager_shared_project_root>`. 
-For more details on customization and configuration of the Project Manager, see :ref:`project_manager`, or 
-see :ref:`project-manager-tutorial` for an example driven guide intended for users.
+For more details on customization and configuration, see the :ref:`Project Manager docs <project_manager>`, 
+and for an example driven guide intended for users, see :ref:`project-manager-tutorial`.
 
-.. warning::
-   The Job Composer is officially **deprecated** in 4.1, and will no longer receive new features or bug fixes
-   beyond critical maintenance. Although the Project Manager covers and surpasses all Job Composer functionality,
-   the Job Composer will remain enabled as a legacy feature until version 5.0.
 
 Help, Support and Institutional Integration
 -------------------------------------------

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -356,7 +356,7 @@ The Project Manager
 ...................
 
 Version 4.1 enables the Project Manager by default, a new alternative to the Job Composer that brings the
-automatic slurm interaction of batch connect forms to your personal job scripts. In addition to this core 
+automatic scheduler interaction of batch connect forms to your personal job scripts. In addition to this core 
 functionality, it also provides support for workflows that can submit multiple dependent jobs at once, and
 easy collaboration on projects among teams. The core functionality will work without modification, but
 collaborative projects work best when used with :ref:`properly configured shared direcories <project_manager_shared_project_root>`. 


### PR DESCRIPTION
Fixes #1242. Announces the Project Manager in the 4.1 release notes, and announces the deprecation of the Job Composer

https://osc.github.io/ood-documentation-test/add-pm-note-1242/release-notes/v4.1-release-notes.html#the-project-manager
