### PR TITLE
Review of 4.1 release notes

### DIFF
--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -12,7 +12,7 @@ Acknowledgments
 We'd like to thank all these Github users for making their first contributions
 to this project.
 
-* ``wpoely86`` made their first contribution in '#4068 <https://github.com/OSC/ondemand/pull/4068>`_
+* ``wpoely86`` made their first contribution in `#4068 <https://github.com/OSC/ondemand/pull/4068>`_
 * ``harshit-soora`` made their first contribution in [#4069](https://github.com/OSC/ondemand/pull/4069)
 * ``hansen-m`` made their first contribution in [#4111](https://github.com/OSC/ondemand/pull/4111)
 * ``junousi`` made their first contribution in [#4122](https://github.com/OSC/ondemand/pull/4122)

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -12,7 +12,7 @@ Acknowledgments
 We'd like to thank all these Github users for making their first contributions
 to this project.
 
-* ``wpoely86`` made their first contribution in [#4068](https://github.com/OSC/ondemand/pull/4068)
+* ``wpoely86`` made their first contribution in '#4068 <https://github.com/OSC/ondemand/pull/4068>`_
 * ``harshit-soora`` made their first contribution in [#4069](https://github.com/OSC/ondemand/pull/4069)
 * ``hansen-m`` made their first contribution in [#4111](https://github.com/OSC/ondemand/pull/4111)
 * ``junousi`` made their first contribution in [#4122](https://github.com/OSC/ondemand/pull/4122)

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -13,34 +13,34 @@ We'd like to thank all these Github users for making their first contributions
 to this project.
 
 * ``wpoely86`` made their first contribution in `#4068 <https://github.com/OSC/ondemand/pull/4068>`_
-* ``harshit-soora`` made their first contribution in [#4069](https://github.com/OSC/ondemand/pull/4069)
-* ``hansen-m`` made their first contribution in [#4111](https://github.com/OSC/ondemand/pull/4111)
-* ``junousi`` made their first contribution in [#4122](https://github.com/OSC/ondemand/pull/4122)
-* ``JanssenAaron``  made their first contribution in [#4133](https://github.com/OSC/ondemand/pull/4133)
-* ``hsmallbone``  made their first contribution in [#4142](https://github.com/OSC/ondemand/pull/4142)
-* ``devanyk2``  made their first contribution in [#4166](https://github.com/OSC/ondemand/pull/4166)
-* ``adamboutcher``  made their first contribution in [#4212](https://github.com/OSC/ondemand/pull/4212)
-* ``genericdata``  made their first contribution in [#4237](https://github.com/OSC/ondemand/pull/4237)
-* ``Vibe-Guy``  made their first contribution in [#4355](https://github.com/OSC/ondemand/pull/4355)
-* ``yuvipanda``  made their first contribution in [#4410](https://github.com/OSC/ondemand/pull/4410)
-* ``bedroesb``  made their first contribution in [#4439](https://github.com/OSC/ondemand/pull/4439)
-* ``simonLeary42``  made their first contribution in [#4476](https://github.com/OSC/ondemand/pull/4476)
-* ``Bubballoo3``  made their first contribution in [#4492](https://github.com/OSC/ondemand/pull/4492)
-* ``twhitehead``  made their first contribution in [#4504](https://github.com/OSC/ondemand/pull/4504)
-* ``brandonbiggs``  made their first contribution in [#4511](https://github.com/OSC/ondemand/pull/4511)
-* ``moffatsadeghi``  made their first contribution in [#4534](https://github.com/OSC/ondemand/pull/4534)
-* ``nd996``  made their first contribution in [#4561](https://github.com/OSC/ondemand/pull/4561)
-* ``epruesse``  made their first contribution in [#4586](https://github.com/OSC/ondemand/pull/4586)
-* ``mw-a``  made their first contribution in [#4601](https://github.com/OSC/ondemand/pull/4601)
-* ``RuttJen``  made their first contribution in [#4582](https://github.com/OSC/ondemand/pull/4582)
-* ``jmeddick``  made their first contribution in [#4532](https://github.com/OSC/ondemand/pull/4532)
-* ``yarikoptic``  made their first contribution in [#4671](https://github.com/OSC/ondemand/pull/4671)
-* ``GlazerMann``  made their first contribution in [#4721](https://github.com/OSC/ondemand/pull/4721)
-* ``jgoodson``  made their first contribution in [#4710](https://github.com/OSC/ondemand/pull/4710)
-* ``mrgum``  made their first contribution in [#4747](https://github.com/OSC/ondemand/pull/4747)
-* ``honza801``  made their first contribution in [#4784](https://github.com/OSC/ondemand/pull/4784)
-* ``fodinabor``  made their first contribution in [#4814](https://github.com/OSC/ondemand/pull/4814)
-* ``Cinnamals``  made their first contribution in [#4839](https://github.com/OSC/ondemand/pull/4839)
+* ``harshit-soora`` made their first contribution in `#4069 <https://github.com/OSC/ondemand/pull/4069>`_
+* ``hansen-m`` made their first contribution in `#4111 <https://github.com/OSC/ondemand/pull/4111>`_
+* ``junousi`` made their first contribution in `#4122 <https://github.com/OSC/ondemand/pull/4122>`_
+* ``JanssenAaron``  made their first contribution in `#4133 <https://github.com/OSC/ondemand/pull/4133>`_
+* ``hsmallbone``  made their first contribution in `#4142 <https://github.com/OSC/ondemand/pull/4142>`_
+* ``devanyk2``  made their first contribution in `#4166 <https://github.com/OSC/ondemand/pull/4166>`_
+* ``adamboutcher``  made their first contribution in `#4212 <https://github.com/OSC/ondemand/pull/4212>`_
+* ``genericdata``  made their first contribution in `#4237 <https://github.com/OSC/ondemand/pull/4237>`_
+* ``Vibe-Guy``  made their first contribution in `#4355 <https://github.com/OSC/ondemand/pull/4355>`_
+* ``yuvipanda``  made their first contribution in `#4410 <https://github.com/OSC/ondemand/pull/4410>`_
+* ``bedroesb``  made their first contribution in `#4439 <https://github.com/OSC/ondemand/pull/4439>`_
+* ``simonLeary42``  made their first contribution in `#4476 <https://github.com/OSC/ondemand/pull/4476>`_
+* ``Bubballoo3``  made their first contribution in `#4492 <https://github.com/OSC/ondemand/pull/4492>`_
+* ``twhitehead``  made their first contribution in `#4504 <https://github.com/OSC/ondemand/pull/4504>`_
+* ``brandonbiggs``  made their first contribution in `#4511 <https://github.com/OSC/ondemand/pull/4511>`_
+* ``moffatsadeghi``  made their first contribution in `#4534 <https://github.com/OSC/ondemand/pull/4534>`_
+* ``nd996``  made their first contribution in `#4561 <https://github.com/OSC/ondemand/pull/4561>`_
+* ``epruesse``  made their first contribution in `#4586 <https://github.com/OSC/ondemand/pull/4586>`_
+* ``mw-a``  made their first contribution in `#4601 <https://github.com/OSC/ondemand/pull/4601>`_
+* ``RuttJen``  made their first contribution in `#4582 <https://github.com/OSC/ondemand/pull/4582>`_
+* ``jmeddick``  made their first contribution in `#4532 <https://github.com/OSC/ondemand/pull/4532>`_
+* ``yarikoptic``  made their first contribution in `#4671 <https://github.com/OSC/ondemand/pull/4671>`_
+* ``GlazerMann``  made their first contribution in `#4721 <https://github.com/OSC/ondemand/pull/4721>`_
+* ``jgoodson``  made their first contribution in `#4710 <https://github.com/OSC/ondemand/pull/4710>`_
+* ``mrgum``  made their first contribution in `#4747 <https://github.com/OSC/ondemand/pull/4747>`_
+* ``honza801``  made their first contribution in `#4784 <https://github.com/OSC/ondemand/pull/4784>`_
+* ``fodinabor``  made their first contribution in `#4814 <https://github.com/OSC/ondemand/pull/4814>`_
+* ``Cinnamals``  made their first contribution in `#4839 <https://github.com/OSC/ondemand/pull/4839>`_
 
 Breaking Changes and Deprecations
 ---------------------------------

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -12,41 +12,40 @@ Acknowledgments
 We'd like to thank all these Github users for making their first contributions
 to this project.
 
-* ``wpoely86`` made their first contribution in https://github.com/OSC/ondemand/pull/4068
-* ``harshit-soora`` made their first contribution in https://github.com/OSC/ondemand/pull/4069
-* ``hansen-m`` made their first contribution in https://github.com/OSC/ondemand/pull/4111
-* ``junousi`` made their first contribution in https://github.com/OSC/ondemand/pull/4122
-* ``JanssenAaron``  made their first contribution in https://github.com/OSC/ondemand/pull/4133
-* ``hsmallbone``  made their first contribution in https://github.com/OSC/ondemand/pull/4142
-* ``devanyk2``  made their first contribution in https://github.com/OSC/ondemand/pull/4166
-* ``adamboutcher``  made their first contribution in https://github.com/OSC/ondemand/pull/4212
-* ``genericdata``  made their first contribution in https://github.com/OSC/ondemand/pull/4237
-* ``Vibe-Guy``  made their first contribution in https://github.com/OSC/ondemand/pull/4355
-* ``yuvipanda``  made their first contribution in https://github.com/OSC/ondemand/pull/4410
-* ``bedroesb``  made their first contribution in https://github.com/OSC/ondemand/pull/4439
-* ``simonLeary42``  made their first contribution in https://github.com/OSC/ondemand/pull/4476
-* ``Bubballoo3``  made their first contribution in https://github.com/OSC/ondemand/pull/4492
-* ``rahimkhoja``  made their first contribution in https://github.com/OSC/ondemand/pull/4512
-* ``twhitehead``  made their first contribution in https://github.com/OSC/ondemand/pull/4504
-* ``brandonbiggs``  made their first contribution in https://github.com/OSC/ondemand/pull/4511
-* ``moffatsadeghi``  made their first contribution in https://github.com/OSC/ondemand/pull/4534
-* ``nd996``  made their first contribution in https://github.com/OSC/ondemand/pull/4561
-* ``epruesse``  made their first contribution in https://github.com/OSC/ondemand/pull/4586
-* ``mw-a``  made their first contribution in https://github.com/OSC/ondemand/pull/4601
-* ``RuttJen``  made their first contribution in https://github.com/OSC/ondemand/pull/4582
-* ``jmeddick``  made their first contribution in https://github.com/OSC/ondemand/pull/4532
-* ``yarikoptic``  made their first contribution in https://github.com/OSC/ondemand/pull/4671
-* ``GlazerMann``  made their first contribution in https://github.com/OSC/ondemand/pull/4721
-* ``jgoodson``  made their first contribution in https://github.com/OSC/ondemand/pull/4710
-* ``mrgum``  made their first contribution in https://github.com/OSC/ondemand/pull/4747
-* ``honza801``  made their first contribution in https://github.com/OSC/ondemand/pull/4784
-* ``fodinabor``  made their first contribution in https://github.com/OSC/ondemand/pull/4814
-* ``Cinnamals``  made their first contribution in https://github.com/OSC/ondemand/pull/4839
+* ``wpoely86`` made their first contribution in [#4068](https://github.com/OSC/ondemand/pull/4068)
+* ``harshit-soora`` made their first contribution in [#4069](https://github.com/OSC/ondemand/pull/4069)
+* ``hansen-m`` made their first contribution in [#4111](https://github.com/OSC/ondemand/pull/4111)
+* ``junousi`` made their first contribution in [#4122](https://github.com/OSC/ondemand/pull/4122)
+* ``JanssenAaron``  made their first contribution in [#4133](https://github.com/OSC/ondemand/pull/4133)
+* ``hsmallbone``  made their first contribution in [#4142](https://github.com/OSC/ondemand/pull/4142)
+* ``devanyk2``  made their first contribution in [#4166](https://github.com/OSC/ondemand/pull/4166)
+* ``adamboutcher``  made their first contribution in [#4212](https://github.com/OSC/ondemand/pull/4212)
+* ``genericdata``  made their first contribution in [#4237](https://github.com/OSC/ondemand/pull/4237)
+* ``Vibe-Guy``  made their first contribution in [#4355](https://github.com/OSC/ondemand/pull/4355)
+* ``yuvipanda``  made their first contribution in [#4410](https://github.com/OSC/ondemand/pull/4410)
+* ``bedroesb``  made their first contribution in [#4439](https://github.com/OSC/ondemand/pull/4439)
+* ``simonLeary42``  made their first contribution in [#4476](https://github.com/OSC/ondemand/pull/4476)
+* ``Bubballoo3``  made their first contribution in [#4492](https://github.com/OSC/ondemand/pull/4492)
+* ``twhitehead``  made their first contribution in [#4504](https://github.com/OSC/ondemand/pull/4504)
+* ``brandonbiggs``  made their first contribution in [#4511](https://github.com/OSC/ondemand/pull/4511)
+* ``moffatsadeghi``  made their first contribution in [#4534](https://github.com/OSC/ondemand/pull/4534)
+* ``nd996``  made their first contribution in [#4561](https://github.com/OSC/ondemand/pull/4561)
+* ``epruesse``  made their first contribution in [#4586](https://github.com/OSC/ondemand/pull/4586)
+* ``mw-a``  made their first contribution in [#4601](https://github.com/OSC/ondemand/pull/4601)
+* ``RuttJen``  made their first contribution in [#4582](https://github.com/OSC/ondemand/pull/4582)
+* ``jmeddick``  made their first contribution in [#4532](https://github.com/OSC/ondemand/pull/4532)
+* ``yarikoptic``  made their first contribution in [#4671](https://github.com/OSC/ondemand/pull/4671)
+* ``GlazerMann``  made their first contribution in [#4721](https://github.com/OSC/ondemand/pull/4721)
+* ``jgoodson``  made their first contribution in [#4710](https://github.com/OSC/ondemand/pull/4710)
+* ``mrgum``  made their first contribution in [#4747](https://github.com/OSC/ondemand/pull/4747)
+* ``honza801``  made their first contribution in [#4784](https://github.com/OSC/ondemand/pull/4784)
+* ``fodinabor``  made their first contribution in [#4814](https://github.com/OSC/ondemand/pull/4814)
+* ``Cinnamals``  made their first contribution in [#4839](https://github.com/OSC/ondemand/pull/4839)
 
 Breaking Changes and Deprecations
 ---------------------------------
 
-The only breaking changes in 4.1 are with the operating system support changes
+The only breaking changes in version 4.1 are with the operating system support changes
 and NodeJS dependency changes listed in the next two sections.
 
 .. warning:: 
@@ -57,9 +56,8 @@ and NodeJS dependency changes listed in the next two sections.
 Operating System Support
 ------------------------
 
-OnDemand 4.1 adds support for RHEL/Rocky/AlmaLinux 10.
-
-OnDemand 4.1 drops support for Ubuntu 20.04.
+- Open OnDemand version 4.1 adds support for RHEL/Rocky/AlmaLinux 10.
+- Open OnDemand version 4.1 drops support for Ubuntu 20.04.
 
 Dependency Updates
 ------------------
@@ -73,19 +71,19 @@ This release updates the following dependencies:
 
   .. warning::
 
-    The change in NodeJs version means any Node-based apps that are not
+    The change in NodeJS version means any Node-based apps that are not
     provided by the OnDemand RPM must be rebuilt or supply their own
-    :ref:`nodejs_starter_app_wrapper` to use the older version of NodeJs.
+    :ref:`nodejs_starter_app_wrapper` to use the older version of NodeJS.
 
 SELinux Changes
 ---------------
 
-Add ``ondemand_manage_config_dir`` boolean to allow OnDemand to manage ``.config`` directories labeled with ``config_home_t``
+Add the ``ondemand_manage_config_dir`` boolean to allow Open OnDemand to manage ``.config`` directories labeled with ``config_home_t``
 
 Authentication and Security
 ---------------------------
 
-Lower-casing in user mapping
+Lower-casing in User Mapping
 ............................
 
 The :ref:`user_map_match <ood-portal-generator-user-map-match>` configuration now
@@ -95,12 +93,12 @@ against it.
 See :ref:`the user_map_match documentation <ood-portal-generator-user-map-match>`
 for more details.
 
-Proxying to origins over https
+Proxying to Origins over HTTPS
 ..............................
 
-4.1 introduces the ability to proxy to origin servers over https protocol.
-While continuing to support plain text origins through ``node_uri`` and
-``rnode_uri`` we've added ``secure_node_uri`` and ``secure_rnode_uri``
+Version 4.1 introduces the ability to proxy to origin servers over HTTPS protocol.
+While continuing to support plain-text origins through ``node_uri`` and
+``rnode_uri``, we've added ``secure_node_uri`` and ``secure_rnode_uri``
 configurations in ``ood_portal.yml``.
 
 See the :ref:`ood_portal.yml configuration for secure proxies<ood-portal-generator-configuration-secure-proxy>`
@@ -109,8 +107,8 @@ for more information.
 Expanded Registration Options
 .............................
 
-More ``ood_portal.yml`` options for registering users have been added in 4.1.
-They are ``register_path``, ``register_method`` and ``register_method_options``.
+More ``ood_portal.yml`` options for registering users have been added in version 4.1.
+They are ``register_path``, ``register_method``, and ``register_method_options``.
 
 See :ref:`ood-portal-generator-user-registration` for more details.
 
@@ -122,7 +120,7 @@ Passenger Telemetry Now Disabled By Default
 
 `Passenger anonymous telemetry <https://www.phusionpassenger.com/docs/advanced_guides/in_depth/ruby/anonymous_telemetry_reporting.html>`__
 is now disabled by default in version 4.1. If you would like to override this default 
-and enable passenger telemetry, you can add ``passenger_disable_anonymous_telemetry: 'off'``
+and enable Passenger telemetry, you can add ``passenger_disable_anonymous_telemetry: 'off'``
 to your :ref:`passenger_options hash <passenger_options>`. Note that this change has also been
 backported in the 4.0.4 and 3.1.12 releases.
 
@@ -143,8 +141,6 @@ allowing users and administrators to differentiate between log entries produced 
 
 Accessibility and Usability
 ---------------------------
-* Any UX or UI stuff
-* Accessibility improvements
 
 Dynamic Forms and Session Cards Announce to Screen Readers
 ..........................................................
@@ -160,21 +156,25 @@ New Skip Navigation Button
 
 Version 4.1 adds a new skip navigation button to the dashboard, which can be accessed
 through keyboard navigation at the top of the page, and is read directly after the 
-page title by screen readers. Clicking the button allows you to bypass the all navigation
+page title by screen readers. Clicking the button allows you to bypass all navigation
 bar items and reliably skip to the main content of the page.
 
 New Dashboard Widgets
 .....................
 
 New dashboard widgets have been added in this release. They include ``balances``, ``file_quotas``,
-``nsf_access_events`` and ``system_status``.
+``nsf_access_events``, and ``system_status``.
+
+For ACCESS Resource Providers (RPs), the ``nsf_access_events`` widget provides a centralized 
+view of upcoming ACCESS events relevant to your site through the Open OnDemand dashboard. 
+Additional RP-focused widgets are planned for future releases.
 
 See :ref:`dashboard_custom_layout` for more details.
 
 New Canadian Internationalization Files
 .......................................
 
-Open OnDemand v4.1 will be the first to include Canadian internationalization 
+Open OnDemand version 4.1 will be the first to include Canadian internationalization 
 files for both English and French, thanks to Rahim Khoja of the University of 
 Alberta. This adds to pre-existing internationalization files for American 
 English, Chinese, and Japanese. It is easy to :ref:`customize or generate your 
@@ -188,15 +188,12 @@ New Demo Container
 
 A new demo container has been made available, allowing you to spin up a lightweight and
 preconfigured OnDemand instance on your own machine. The container allows you to preview
-all of the basic file management, shell, and batch connect features OnDemand has to offer,
-including running a full interactive Jupyter server. For more details and directions on how 
-to pull down and run, see the `ood-demo repository <https://github.com/OSC/ood-demo>`_ on GitHub.
+all of the basic file management, the shell, and batch connect features Open OnDemand has to offer,
+including running a full, interactive Jupyter server. For more details and directions on how 
+to pull down and run the demo, see the `ood-demo repository <https://github.com/OSC/ood-demo>`_ on GitHub.
 
 Interactive Jobs and Applications
 ---------------------------------
-* Batch Connect
-* Interactive sessions
-* Job cards, session information, submission things
 
 Batch Connect Apps Cache ERB Content
 ....................................
@@ -205,7 +202,7 @@ All batch connect apps now cache ERB content, allowing expensive ERB operations 
 done in ``form.yml.erb`` without burdening the web server on each page visit. For app 
 development, this means that changes may not be picked up right away, and you may need 
 to periodically clear the cache by selecting *Help* → *Restart Web Server* from the top 
-right of the navbar. For more details on using ERB in user forms, see 
+right of the navigation bar. For more details on using ERB in user forms, see 
 :ref:`app-development-interactive-form`.
 
 Session Cards Now Have 'Download as Zip' Button
@@ -223,7 +220,7 @@ Sessions Cards Show Cores and GPUs Requested
 
 Session cards now have widgets to display cores and GPUs available to the job, making it
 easier to view the parameters of current or past jobs when re-running for your next session.
-Note that resource widgets will only appear when the quantity requested is greater than 0.
+Please note that resource widgets will only appear when the quantity requested is greater than 0.
 
 New Option For Interactive Session Notifications
 ................................................
@@ -246,15 +243,15 @@ either nodes or cores depending on the scheduler. For more details, see :ref:`bc
 New ``auto_cores`` Functionality
 ................................
 
-Open OnDemand now offers the ``auto_cores`` smart attribute, which allows you to request cores across schedulers.
+Version 4.1 offers the ``auto_cores`` smart attribute, which allows you to request cores across schedulers.
 When used alongside the ``auto_batch_cluster`` attribute, this ensures that the number of cores selected is valid
 for the cluster you are submitting to. For more details, see :ref:`auto_batch_clusters` and :ref:`auto_cores`.
 
 Automatic Attributes Support Accounts with Special Characters
 .............................................................
 
-The account aware ``auto_queues`` and ``auto_qos`` now support account names with special characters, widening their 
-compatibility to more centers. This was prioritized for account names as these are among the hardest to modify, but 
+The account-aware ``auto_queues`` and ``auto_qos`` now support account names with special characters, widening their 
+compatibility with more centers. This was prioritized for account names as these are among the hardest to modify, but 
 the same special character support can be added to other automatic attributes like clusters or queues upon request.
 Note that in order to get the account-aware features from these attributes, they must be used along with 
 ``auto_accounts``.
@@ -324,8 +321,8 @@ Files, Projects, and Data Management
 File Browser Can Now Render HTML Files
 ......................................
 
-Open OnDemand v4.1 brings back HTML rendering within the files app, allowing users
-to open and view HTML files directly. This is disabled by default due to security 
+Open OnDemand version 4.1 brings back HTML rendering within the files app, allowing users
+to open and view HTML files directly. This is disabled by default, due to security 
 concerns, but can be enabled by setting ``OOD_UNSAFE_RENDER_HTML=true`` in your 
 environment or including ``unsafe_render_html=true`` in your :ref:`ondemand-d-ymls`.
 
@@ -335,7 +332,7 @@ File Downloads Have a Maximum Size
 Version 4.1 adds a configurable maximum size for file downloads, which also applies to 
 opening files in the file browser. This can be configured with the ``OOD_DOWNLOAD_FILE_MAX`` 
 environment variable, or setting ``download_file_max`` in your :ref:`ondemand-d-ymls`. 
-This variable accepts plain integer values, and defaults to 10GiB. Note that size 
+This variable accepts plain integer values, and defaults to 10GiB. Please note that size 
 configurations always accept an integer number of (binary) bytes, so the default 10GiB 
 would be represented as ``10737418240``. For more details on this configuration, as well 
 as a similar one for directory downloads, see :ref:`set_download_limits`.
@@ -343,7 +340,7 @@ as a similar one for directory downloads, see :ref:`set_download_limits`.
 File Editor Has a Maximum Size
 ..............................
 
-As of v4.1 the file editor will not open files above a configurable maximum size. The default is 12MiB,
+In version 4.1, the file editor will not open files above a configurable maximum size. The default is 12MiB,
 but this can be changed by setting the ``OOD_FILE_EDITOR_MAX_SIZE`` environment variable, or setting 
 ``file_editor_max_size`` in your :ref:`ondemand-d-ymls`. This uses the same binary byte format as 
 ``OOD_DOWNLOAD_FILE_MAX`` above, so the 12MiB default would be represented as ``12582912``.
@@ -366,9 +363,9 @@ Version 4.1 enables the Project Manager by default, a new alternative to the Job
 automatic scheduler interaction of batch connect forms to your personal job scripts. In addition to this core 
 functionality, it also provides support for workflows that can submit multiple dependent jobs at once, and
 easy collaboration on projects among teams. The core functionality will work without modification, but
-collaborative projects work best when used with :ref:`properly configured shared direcories <project_manager_shared_project_root>`. 
+collaborative projects work best when used with :ref:`properly configured shared directories <project_manager_shared_project_root>`. 
 For more details on customization and configuration, see the :ref:`Project Manager docs <project_manager>`, 
-and for an example driven guide intended for users, see :ref:`project-manager-tutorial`.
+and for an example-driven guide intended for users, see :ref:`project-manager-tutorial`.
 
 
 Help, Support and Institutional Integration
@@ -385,22 +382,20 @@ Module Browser Page
 
 Centers that have enabled :ref:`lmod module suppport <module_file_dir>` for
 OnDemand to read all the modules on clusters will now see a web page for
-searching and displaying these modules.
-
-This new page is under the 'Clusters' menu.
+searching and displaying these modules. This new page is under the 'Clusters' menu in the navigation bar.
 
 Upgrade Instructions
 --------------------
 
 .. warning::
 
-   Update the **development** and/or **test** instances of OnDemand installed at your center **before** before you modify the **production** instance.
+   Update the **development** and/or **test** instances of OnDemand installed at your center **before** you modify the **production** instance.
 
 .. warning::
 
-  We have tested the upgrade from 4.0.8 to 4.1.0 at OSC's OnDemand instance.
+  We have tested the upgrade from version 4.0.8 to version 4.1.0 at OSC's Open OnDemand instance.
 
-#. Update OnDemand repository.
+#. Update Open OnDemand repository.
 
    .. tabs::
 
@@ -453,7 +448,7 @@ Upgrade Instructions
       sudo dnf module reset nodejs
       sudo dnf module enable nodejs:22
 
-#. Update OnDemand
+#. Update Open OnDemand.
 
    .. tabs::
 


### PR DESCRIPTION
Updated the release notes for version 4.1 to improve clarity and consistency in formatting, including changes to user contributions, breaking changes, and feature descriptions.

https://osc.github.io/ood-documentation-test/moffatsadeghi-4.1releasenotes1

Grammar, misspellings, adding version, correcting to open ondemand, adding little tweaks here and there, shortening sentences for new contributors to hyperlink-type format, etc.
