### PR TITLE
rm warning on partition

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -761,12 +761,6 @@ The following configuration file
 
 defines a session context attribute called ``my_module_version``.
 
-.. warning::
-
-   Do not use ``partition`` as attribute name within the form. The (Ruby)
-   object created by the form is of type enumerable and ``partition`` is
-   method of that particular class. This causes the value set in the form not
-   being correctly passed to the submit script.
 
 After modifying the ``form.yml`` click *Launch My App* from the Dashboard
 sandbox app list and you will see an empty text box with the label "My Module


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/rm-partition/

remove this warning on partition as it's no longer valid (i.e., partition works now)
