### PR TITLE
add docs on stripping headers in 4.1

### DIFF
--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -325,6 +325,46 @@ Configure General Options
 
           security_strict_transport: false
 
+.. _ood-portal-generator-strip-proxy-headers:
+
+.. describe:: strip_proxy_headers (Array)
+
+  Since 4.1 the Open OnDemand portal will strip these sensitive HTTP headers when proxying
+  requests to interactive applications for enhanced security.
+
+    Default
+      Strip many authentication related headers.
+
+      .. code-block:: yaml
+
+        strip_proxy_headers: ["Authorization", "OIDC_CLAIM_sub", "OIDC_CLAIM_preferred_username", "OIDC_CLAIM_given_name", "OIDC_CLAIM_zoneinfo", "OIDC_CLAIM_locale", "OIDC_CLAIM_email", "OIDC_CLAIM_email_verified", "OIDC_CLAIM_iss", "OIDC_CLAIM_nonce", "OIDC_CLAIM_aud", "OIDC_CLAIM_acr", "OIDC_CLAIM_azp", "OIDC_CLAIM_auth_time", "OIDC_CLAIM_exp", "OIDC_CLAIM_iat", "OIDC_CLAIM_jti", "OIDC_access_token", "OIDC_access_token_expires"]
+
+    Example
+      Strip no authentication related headers. 
+
+      .. code-block:: yaml
+
+        strip_proxy_headers: []
+
+.. describe:: strip_proxy_cookies (Array)
+
+  Since 4.1 the Open OnDemand portal will strip these sensitive HTTP cookies when proxying
+  requests to interactive applications for enhanced security.
+
+    Default
+      Strip ``mod_auth_openidc_session`` cookies.
+
+      .. code-block:: yaml
+
+        strip_proxy_cookies: ["mod_auth_openidc_session_\\d+", "mod_auth_openidc_session"]
+
+    Example
+      Do not strip any cookies.
+
+      .. code-block:: yaml
+
+        strip_proxy_cookies: []
+
 .. describe:: lua_root (String)
 
      the root directory where the Lua handler code resides

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -99,10 +99,10 @@ NodeJS breaking change
 and NodeJS dependency changes listed in the next two sections.
 
 
-Stripping Sensitve Headers
-..........................
+Stripping Sensitive Headers
+...........................
 
-For additional security, 4.1 will now strip certain senstive headers when proxying
+For additional security, 4.1 will now strip certain sensitive headers when proxying
 to interactive applications. See the `Strip Sensitive Headers and Cookies`_ section below
 for more details.
 
@@ -186,7 +186,7 @@ Strip Sensitive Headers and Cookies
 
 4.1 introduced two new configurations ``strip_proxy_headers`` and ``strip_proxy_cookies``
 to strip headers and cookies when proxying requests to interactive applications.  These
-were added as a security measure against possibly leaking senstive data to interactive
+were added as a security measure against possibly leaking sensitive data to interactive
 applications.
 
 See :ref:`the ood_portal.yml configuration for strip_proxy_headers and strip_proxy_cookies <ood-portal-generator-strip-proxy-headers>` for more details.

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -91,13 +91,27 @@ first time in this release. These contributions span the ``ondemand``, ``ood_cor
 Breaking Changes and Deprecations
 ---------------------------------
 
-The only breaking changes in version 4.1 are with the operating system support changes
+
+NodeJS breaking change
+......................
+
+4.1 has upgrade ``NodeJS`` dependency. See the operating system support changes
 and NodeJS dependency changes listed in the next two sections.
 
-.. warning:: 
-  The Job Composer is officially **deprecated** in 4.1, and will no longer receive new features or bug fixes
-  beyond critical maintenance. Although the :ref:`new Project Manager <project-manager-note>` covers and 
-  surpasses all Job Composer functionality, the Job Composer will remain enabled as a legacy feature until version 5.0.
+
+Stripping Sensitve Headers
+..........................
+
+For additional security, 4.1 will now strip certain senstive headers when proxying
+to interactive applications. See the `Strip Sensitive Headers and Cookies`_ section below
+for more details.
+
+Job Composer is now Deprecated
+..............................
+
+The Job Composer is officially **deprecated** in 4.1, and will no longer receive new features or bug fixes
+beyond critical maintenance. Although the :ref:`new Project Manager <project-manager-note>` covers and 
+surpasses all Job Composer functionality, the Job Composer will remain enabled as a legacy feature until version 5.0.
 
 Operating System Support
 ------------------------
@@ -166,6 +180,16 @@ More ``ood_portal.yml`` options for registering users have been added in version
 They are ``register_path``, ``register_method``, and ``register_method_options``.
 
 See :ref:`ood-portal-generator-user-registration` for more details.
+
+Strip Sensitive Headers and Cookies
+...................................
+
+4.1 introduced two new configurations ``strip_proxy_headers`` and ``strip_proxy_cookies``
+to strip headers and cookies when proxying requests to interactive applications.  These
+were added as a security measure against possibly leaking senstive data to interactive
+applications.
+
+See :ref:`the ood_portal.yml configuration for strip_proxy_headers and strip_proxy_cookies <ood-portal-generator-strip-proxy-headers>` for more details.
 
 Platform Configuration, Operations, and Observability
 -----------------------------------------------------


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/strip-proxy-config/

Add documentation on the 2 new ood_portal configurations for stripping certain headers.

Note that I've also updated the breaking changes section to include this and reformatted the job composer deprecation section. It just seemed to flow better when adding multiple items in this section.
