### PR TITLE
typo: in submit-yml/basic-bc-options script_file -> timeout

### DIFF
--- a/source/reference/files/submit-yml/basic-bc-options.rst
+++ b/source/reference/files/submit-yml/basic-bc-options.rst
@@ -265,14 +265,14 @@ Basic Batch Connect Options
 
       .. code-block:: yaml
 
-        script_file: ""
+        timeout: ""
 
     Example
       all scripts timeout after 3600 seconds (1 hour)
 
       .. code-block:: yaml
 
-        script_file: "3600"
+        timeout: "3600"
 
 .. describe:: clean_script (String, "...")
 


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation/latest/reference/files/submit-yml/basic-bc-options.html

**Add your description here**

Minor typo where the option should be timeout, but it is script_file:
https://github.com/OSC/ood-documentation/blob/a5e74f293e984f2b7fcd275bf963a6a334675c29/source/reference/files/submit-yml/basic-bc-options.rst?plain=1#L259-L275

fixes https://github.com/OSC/ood-documentation/issues/1331