### PR TITLE
Add accessibility recommendation for enabling `show_all_apps_link`

### DIFF
--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -1026,6 +1026,8 @@ In each default translation dictionary file the values that are most site-specif
 
 .. _Yaml spec: https://yaml.org/spec/1.2/spec.html#id2777534
 
+.. _change_welcome_html:
+
 Change the Dashboard Tagline
 ............................
 

--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -12,18 +12,15 @@ Acknowledgments
 Accessibility Recommendations
 -----------------------------
 
-A VPAT has been created for version 4.2 and outlines the compliance of Open OnDemand with the AA WCAG standard.
+A VPAT has been created for version 4.2 and outlines the compliance of Open OnDemand with the WCAG AA standard.
 Changes in version 4.2 ensure that immutable aspects of OnDemand are accessible by default, but do not account for
 customizations configured on individual instances. An individual instance should be reviewed separately for compliance,
 but we recommend specifically checking the following configurations that are directly related to WCAG guidelines.
 
 - Ensure ``show_all_apps_link`` is set to true to satisfy `2.4.5 Multiple Ways <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc>`_
-   - This page acts as a searchable site map to all the enabled apps on your system. In addition to enabling the link in the navbar, it may be helpful to call attention and link to it in your :ref:`homepage welcome message <change_welcome_html>`. 
+   - This page acts as a searchable site map to all the enabled apps on your system. In addition to enabling the link in the navbar, it may be helpful to call attention and link to it in your :ref:`homepage welcome message <change_welcome_html>`.
+   - The default value has been changed from false to true in v4.2. Ensure that your custom configuration does not override this default.
    - The ``show_all_apps_link`` configuration can be set through the environment variable ``SHOW_ALL_APPS_LINK`` or in your :ref:`ondemand-d-ymls`.
-
-.. warning::
-   The default value for ``show_all_apps_link`` is ``false`` in version 4.2.1. This default will be updated to ``true`` 
-   in subsequent patches, but means that **this configuration must be set** to meet AA compliance.
 
 
 Operating System Support

--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -9,8 +9,22 @@ v4.2 Release Notes
 Acknowledgments
 ---------------
 
-Breaking Changes and Deprecations
----------------------------------
+Accessibility Recommendations
+-----------------------------
+
+A VPAT has been created for version 4.2 and outlines the compliance of Open OnDemand with the AA WCAG standard.
+Changes in version 4.2 ensure that immutable aspects of OnDemand are accessible by default, but do not account for
+customizations configured on individual instances. An individual instance should be reviewed separately for compliance,
+but we recommend specifically checking the following configurations that are directly related to WCAG guidelines.
+
+- Ensure ``show_all_apps_link`` is set to true to satisfy `2.4.5 Multiple Ways <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc>`_
+   - This page acts as a searchable site map to all the enabled apps on your system. In addition to enabling the link in the navbar, it may be helpful to call attention and link to it in your :ref:`homepage welcome message <change_welcome_html>`. 
+   - The ``show_all_apps_link`` configuration can be set through the environment variable ``SHOW_ALL_APPS_LINK`` or in your :ref:`ondemand-d-ymls`.
+
+.. warning::
+   The default value for ``show_all_apps_link`` is ``false`` in version 4.2.1. This default will be updated to ``true`` 
+   in subsequent patches, but means that **this configuration must be set** to meet AA compliance.
+
 
 Operating System Support
 ------------------------


### PR DESCRIPTION
I will leave this open for review as I want to ensure that it covers everything we want to say about it. With this in the release notes, I think we can comfortably mark 'Supports' on the 'Multiple Ways' section of the VPAT.

https://osc.github.io/ood-documentation-test/init-accessibility-recommendations/
