### PR TITLE
Adds accessibility fixes per WCAG 2.1 level AA, audited with pa11y

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -58,7 +58,12 @@ footer p {
   color: #ffffff !important;
   text-decoration: underline;
 }
+
 .admonition a.reference {
+  color: #2071a5 !important;
+}
+
+.admonition.note a.reference {
   color: #000305 !important;
   text-decoration: underline;
 }

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -58,13 +58,6 @@ footer p {
   color: #747474;
 }
 
-/* Admonition title - both class variants */
-.admonition .admonition-title,
-.admonition > .admonition-title {
-  background-color: #367caa;
-  color: #ffffff;
-}
-
 .admonition .admonition-title a {
   color: #ffffff !important;
   text-decoration: underline;
@@ -78,9 +71,7 @@ footer p {
 .wy-nav-side .wy-menu-vertical a {
   color: #ffffff;
 }
-.wy-nav-side .wy-menu-vertical p.caption span.caption-text {
-  color: #ffffff;
-}
+
 .wy-nav-side .wy-menu-vertical li a code,
 .wy-nav-side .wy-menu-vertical li a code span,
 .wy-nav-side .wy-menu-vertical li a code span.pre {
@@ -182,14 +173,7 @@ dt em {
   color: #000305;
 }
 
-.admonition .admonition-title {
-  /* keep your existing title styling */
-}
-
 /* Force readable contrast on admonition body content */
-.admonition {
-  background-color: #ffffff !important;
-}
 
 .admonition .admonition-title {
   /* keep blue background for the title bar */

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -43,4 +43,187 @@ span.c1 {
       overflow: visible !important;
    }
 }
+/* WCAG 2.1 AA contrast fixes */
+a.reference.external,
+a.reference.internal {
+  color: #237ab3;
+}
+a.headerlink {
+  color: #237ab3;
+}
+code span.pre {
+  color: #d83d2d;
+}
+footer p {
+  color: #747474;
+}
 
+/* Admonition title - both class variants */
+.admonition .admonition-title,
+.admonition > .admonition-title {
+  background-color: #367caa;
+  color: #ffffff;
+}
+
+.admonition .admonition-title a {
+  color: #ffffff !important;
+  text-decoration: underline;
+}
+.admonition a.reference {
+  color: #000305 !important;
+  text-decoration: underline;
+}
+
+/* Sidebar nav */
+.wy-nav-side .wy-menu-vertical a {
+  color: #ffffff;
+}
+.wy-nav-side .wy-menu-vertical p.caption span.caption-text {
+  color: #ffffff;
+}
+.wy-nav-side .wy-menu-vertical li a code,
+.wy-nav-side .wy-menu-vertical li a code span,
+.wy-nav-side .wy-menu-vertical li a code span.pre {
+  background: #2D2926 !important;
+  border: none !important;
+  color: #ffffff !important;
+  padding: 0 !important;
+}
+
+.wy-breadcrumbs code,
+.wy-breadcrumbs code span.pre {
+  background: #ffffff !important;
+}
+
+/* Breadcrumbs */
+.wy-breadcrumbs a,
+.wy-breadcrumbs li a {
+  color: #237ab3;
+}
+
+/* Body links */
+.wy-body-for-nav a strong {
+  color: #1a6fa8;
+}
+blockquote a {
+  color: #1a6fa8;
+}
+td a.reference.external,
+td a.reference.internal {
+  color: #1a6fa8 !important;
+}
+td ul a,
+section a {
+  color: #1a6fa8;
+}
+
+/* HTTP domain API signature elements */
+.sig-paren {
+  color: #000305;
+}
+dt em {
+  color: #000305;
+}
+
+/* LSF warning table */
+#lsfwarning td {
+  color: #595959;
+}
+#lsfwarning td em {
+  color: #595959;
+}
+#lsfwarning td em a {
+  color: #1a6fa8 !important;
+}
+#lsfwarning td a.reference {
+  color: #1a6fa8;
+}
+
+/* Screen reader only */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+/* Pygments syntax highlighting contrast fixes (WCAG 2.1 AA) */
+.highlight .c, .highlight .ch, .highlight .cm,
+.highlight .cp, .highlight .cpf, .highlight .c1,
+.highlight .cs { color: #2d6a7a !important; }
+.highlight .o, .highlight .ow { color: #4a4a4a !important; }
+.highlight .s, .highlight .s1, .highlight .s2,
+.highlight .sa, .highlight .sb, .highlight .sc,
+.highlight .dl, .highlight .sd, .highlight .se,
+.highlight .sh, .highlight .si, .highlight .sx,
+.highlight .sr, .highlight .ss,
+.highlight .na { color: #2d5a8e !important; }
+.highlight .nv, .highlight .vc, .highlight .vg,
+.highlight .vi, .highlight .vm { color: #7b3d9e !important; }
+.highlight .go { color: #1a1a1a !important; }
+.highlight .nn { color: #0a6a8a !important; }
+.highlight .no { color: #2d6090 !important; }
+.highlight .gi { color: #007000 !important; }
+.highlight .nc { color: #0a6a8a !important; }
+
+
+/* Admonition body content - ensure readable contrast */
+.admonition {
+  background-color: #ffffff;
+}
+
+.admonition p,
+.admonition li,
+.admonition div {
+  color: #000305;
+}
+
+.admonition .admonition-title {
+  /* keep your existing title styling */
+}
+
+/* Force readable contrast on admonition body content */
+.admonition {
+  background-color: #ffffff !important;
+}
+
+.admonition .admonition-title {
+  /* keep blue background for the title bar */
+  background-color: #367caa !important;
+  color: #ffffff !important;
+}
+
+.admonition.warning .admonition-title,
+.admonition.attention .admonition-title,
+.admonition.caution .admonition-title {
+  background-color: #a56833 !important;
+}
+
+.admonition.tip .admonition-title,
+.admonition.hint .admonition-title {
+  background-color: #00866c !important;
+}
+
+.admonition.important .admonition-title,
+.admonition.danger .admonition-title,
+.admonition.error .admonition-title {
+  background-color: #b15e56 !important;
+}
+
+.admonition p,
+.admonition li,
+.admonition dd,
+.admonition dt {
+  color: #000305 !important;
+  background-color: transparent !important;
+}
+
+#lsfwarning,
+#lsfwarning p,
+#lsfwarning span {
+  color: #747474 !important;
+}

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -2,10 +2,6 @@
   background-color: #C8102E;
 }
 
-.wy-side-nav-search > div.version {
-  color: rgba(255, 255, 255, 0.5);
-}
-
 .wy-side-nav-search > a:hover {
   background: rgba(255, 255, 255, 0.2);
 }
@@ -70,6 +66,10 @@ footer p {
 /* Sidebar nav */
 .wy-nav-side .wy-menu-vertical a {
   color: #ffffff;
+}
+
+.wy-side-nav-search > div.version {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .wy-nav-side .wy-menu-vertical li a code,

--- a/source/_templates/searchbox.html
+++ b/source/_templates/searchbox.html
@@ -1,13 +1,11 @@
 <div id="searchbox" role="search">
-  <h3 id="searchlabel">{{ _('Quick search') }}</h3>
   <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get" id="rtd-search-form" class="wy-form">
-      <label for="search-input" class="sr-only">{{ _('Search docs') }}</label>
       <input
         type="text"
         id="search-input"
         name="q"
-        aria-labelledby="searchlabel"
+        aria-label="Search docs"
         autocomplete="off"
         autocorrect="off"
         autocapitalize="off"

--- a/source/_templates/searchbox.html
+++ b/source/_templates/searchbox.html
@@ -1,0 +1,20 @@
+<div id="searchbox" role="search">
+  <h3 id="searchlabel">{{ _('Quick search') }}</h3>
+  <div class="searchformwrapper">
+    <form class="search" action="{{ pathto('search') }}" method="get" id="rtd-search-form" class="wy-form">
+      <label for="search-input" class="sr-only">{{ _('Search docs') }}</label>
+      <input
+        type="text"
+        id="search-input"
+        name="q"
+        aria-labelledby="searchlabel"
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+        spellcheck="false"
+        placeholder="{{ _('Search docs') }}"
+      />
+      <input type="submit" value="{{ _('Go') }}" class="sr-only" />
+    </form>
+  </div>
+</div>

--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -178,7 +178,6 @@ Currently only the dashboard uses the colors in the navbar.
 
 .. list-table:: Branding
    :header-rows: 1
-   :stub-columns: 1
 
    * - Feature
      - Property
@@ -244,7 +243,6 @@ These URLs can be specified, which will appear in the Help menu and on other loc
 
 .. list-table:: Dashboard URLs
    :header-rows: 1
-   :stub-columns: 1
 
    * - Name
      - Environment variable
@@ -993,7 +991,6 @@ In each default translation dictionary file the values that are most site-specif
 
 .. list-table:: OnDemand Locale Files
   :header-rows: 1
-  :stub-columns: 1
 
   * - File path
     - App

--- a/source/release-notes/v1.0-release-notes.rst
+++ b/source/release-notes/v1.0-release-notes.rst
@@ -29,7 +29,6 @@ Infrastructure
 .. list-table:: Infrastructure Component Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - Component
      - Version
@@ -52,7 +51,6 @@ Applications
 .. list-table:: Application Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - App
      - Version

--- a/source/release-notes/v1.1-release-notes.rst
+++ b/source/release-notes/v1.1-release-notes.rst
@@ -31,7 +31,6 @@ Infrastructure
 .. list-table:: Infrastructure Component Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - Component
      - Version
@@ -54,7 +53,6 @@ Applications
 .. list-table:: Application Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - App
      - Version

--- a/source/release-notes/v1.2-release-notes.rst
+++ b/source/release-notes/v1.2-release-notes.rst
@@ -48,7 +48,6 @@ Infrastructure
 .. list-table:: Infrastructure Component Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - Component
      - Version
@@ -73,7 +72,6 @@ Applications
 .. list-table:: Application Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - App
      - Version

--- a/source/release-notes/v1.3-release-notes.rst
+++ b/source/release-notes/v1.3-release-notes.rst
@@ -170,7 +170,6 @@ Infrastructure Version Changes
 .. list-table:: Infrastructure Component Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - Component
      - Version
@@ -197,7 +196,6 @@ Application Version Changes
 .. list-table:: Application Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - App
      - Version

--- a/source/release-notes/v1.4-release-notes.rst
+++ b/source/release-notes/v1.4-release-notes.rst
@@ -119,7 +119,6 @@ Application Version Changes
 .. list-table:: Application Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - App
      - Version

--- a/source/release-notes/v1.5-release-notes.rst
+++ b/source/release-notes/v1.5-release-notes.rst
@@ -188,7 +188,6 @@ Application Version Changes
 .. list-table:: Application Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - App
      - Version

--- a/source/release-notes/v1.6-release-notes.rst
+++ b/source/release-notes/v1.6-release-notes.rst
@@ -53,7 +53,6 @@ Application Version Changes
 .. list-table:: Application Versions
    :widths: auto
    :header-rows: 1
-   :stub-columns: 1
 
    * - App
      - Version

--- a/source/release-notes/v1.8-release-notes.rst
+++ b/source/release-notes/v1.8-release-notes.rst
@@ -42,7 +42,7 @@ Before upgrading to v1.8, please consider the following:
 .. warning:: Shell hosts are now protected behind allow-lists.  After upgrading, you may need to
     set a default SSH host and add the compute nodes to the allow-lists, as well as any other hosts
     you want to enable access to through the Shell app that are not already specified in the cluster configuration.
-    `See the entry in the release notes for more information. <#shell-hosts-are-now-protected-behind-allowlists>`_
+    `See the entry in the release notes for more information. <#shell-hosts-are-now-protected-behind-allow-lists>`_
 
 
 - If upgrading from OnDemand 1.5.x or older **you must upgrade to 1.6.x before upgrading to 1.7**. See directions for upgrading from 1.4 to 1.5 (:ref:`v1.5-release-notes`) and from 1.5 to 1.6 (:ref:`v1.6-release-notes`).

--- a/source/requirements.rst
+++ b/source/requirements.rst
@@ -15,7 +15,6 @@ At this time OnDemand only supports the following operating systems and architec
 
 .. csv-table:: Operating System and Architecture Support
    :header: "","``x86_64``","``aarch64/arm64``","``ppc64le``"
-   :stub-columns: 1
 
    "RedHat/Rocky Linux/AlmaLinux 8",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#9989;`
    "RedHat/Rocky Linux/AlmaLinux 9",:raw-html:`&#9989;`,:raw-html:`&#9989;`,:raw-html:`&#9989;`


### PR DESCRIPTION
**Modify this link to include the branch name, and possibly the page this PR modifies**:

https://osc.github.io/ood-documentation-test/accessibility_fixes_v2/

**Add your description here**
**Replaces #1333**, rebuilt against current `latest` after the rename of `source/customization.rst` to `source/customizations.rst`. Same scope of changes and same end state (zero pa11y errors across the site), but now cleaned up for an easier merge.
