### PR TITLE
add bc_desktop SAFE_PATH to 4.1 release notes

### DIFF
--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -361,8 +361,8 @@ Desktop safe clean PATH
 .......................
 
 Previous versions of Open OnDemand have had issues with the ``bc_desktop`` application where users who
-specify ``PATH`` in their ``.bashrc`` (generally through conda environments) launching desktops.
-Indeed, previous versions of Open OnDemand have even attempted to fix this. Now, in 4.1, we beleive this
+specify ``PATH`` in their ``.bashrc`` (generally through ``conda`` environments) launching desktops.
+Indeed, previous versions of Open OnDemand have even attempted to fix this. Now, in 4.1, we believe this
 specific issue is resolved because the desktops will strip anything from the users ``HOME`` from the
 ``PATH`` environment variable when starting the desktops.
 

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -360,10 +360,11 @@ their jobs to know when they start running.
 Desktop safe clean PATH
 .......................
 
-Previous versions of Open OnDemand have had issues with the ``bc_desktop`` application where users who
-specify ``PATH`` in their ``.bashrc`` (generally through ``conda`` environments) launching desktops.
-Indeed, previous versions of Open OnDemand have even attempted to fix this. Now, in 4.1, we believe this
-specific issue is resolved because the desktops will strip anything from the users ``HOME`` from the
+Previous versions of Open OnDemand have had issues with the ``bc_desktop`` application when users
+specify ``PATH`` in their ``.bashrc`` (generally through ``conda`` environments).
+Indeed, previous versions of Open OnDemand have even attempted to fix this by hard coding a basic ``PATH``,
+though this had issues of it's own if binaries were outside of a basic ``PATH``. Now, in 4.1, we believe
+this specific issue is resolved because the desktops will strip anything from the users ``HOME`` from the
 ``PATH`` environment variable when starting the desktops.
 
 Forms, Widgets, and User Input

--- a/source/release-notes/v4.1-release-notes.rst
+++ b/source/release-notes/v4.1-release-notes.rst
@@ -357,6 +357,15 @@ their jobs to know when they start running.
 .. figure:: /images/interactive-app-notifications.png
    :alt: The 'My Interactive Sessions' page of Open OnDemand, highlighting the switch to enable notifications.
 
+Desktop safe clean PATH
+.......................
+
+Previous versions of Open OnDemand have had issues with the ``bc_desktop`` application where users who
+specify ``PATH`` in their ``.bashrc`` (generally through conda environments) launching desktops.
+Indeed, previous versions of Open OnDemand have even attempted to fix this. Now, in 4.1, we beleive this
+specific issue is resolved because the desktops will strip anything from the users ``HOME`` from the
+``PATH`` environment variable when starting the desktops.
+
 Forms, Widgets, and User Input
 ------------------------------
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/safe-path/

Fixes #1217.  Unfortunately we don't really have a spot for desktops, beyond how to enable them.  Since users can't modify this app (or this fix to the `PATH`), I can only figure this goes in the release notes.
