### PR TITLE
add a task for cleaning the build workspace

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,11 @@ task :build do
   exec cmd
 end
 
+desc "Clean workspace"
+task :clean do
+  exec "#{run_cmd} make clean"
+end
+
 desc "Spellcheck"
 task :spellcheck do
   exec "#{run_cmd} make spellcheck"


### PR DESCRIPTION
In building recently I found that I wanted a way to clean the workspace to make sure what I was looking at was pristine. So this adds a `rake clean` task to clean the workspace inbetween build edits/git checkouts and so on.

Not a document update so there's no link.