### PR TITLE
Add job composer note

### DIFF
--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -22,6 +22,10 @@ but we recommend specifically checking the following configurations that are dir
    - The default value has been changed from false to true in v4.2. Ensure that your custom configuration does not override this default.
    - The ``show_all_apps_link`` configuration can be set through the environment variable ``SHOW_ALL_APPS_LINK`` or in your :ref:`ondemand-d-ymls`.
 
+- Disable Job Composer
+   - While basic accessibility improvements have been made to the Job Composer, it constitutes a separate set of webpages from the dashboard, and so was not evaluated as part of the VPAT.
+   - In order to meet AA compliance, we recommend disabling the Job Composer and directing users to the Project Manager, which has been fully updated and evaluated for accessibility.
+   - The Job Composer can be easily disabled for all users by an administrator with the command ``sudo chmod 700 /var/www/ood/apps/sys/myjobs``.
 
 Operating System Support
 ------------------------

--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -23,7 +23,7 @@ but we recommend specifically checking the following configurations that are dir
    - The ``show_all_apps_link`` configuration can be set through the environment variable ``SHOW_ALL_APPS_LINK`` or in your :ref:`ondemand-d-ymls`.
 
 - Disable Job Composer
-   - While basic accessibility improvements have been made to the Job Composer, it constitutes a separate set of webpages from the dashboard, and so was not evaluated as part of the VPAT.
+   - While basic accessibility improvements have been made to the Job Composer, it constitutes a separate set of pages from the dashboard, files, and other core apps, and so was not evaluated as part of the VPAT.
    - In order to meet AA compliance, we recommend disabling the Job Composer and directing users to the Project Manager, which has been fully updated and evaluated for accessibility.
    - The Job Composer can be easily disabled for all users by an administrator with the command ``sudo chmod 700 /var/www/ood/apps/sys/myjobs``.
 


### PR DESCRIPTION
Notes that the job composer was not updated to the same accessibility standard as the dashboard and that compliance-oriented sites should disable it.
