### PR TITLE
Add accessibility summary

### DIFF
--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -15,7 +15,7 @@ Accessibility
 Open OnDemand v4.2 includes many accessibility improvements across the dashboard and core applications. These include:
 
  - Additional support for keyboard navigation
- - Improved labelling for form items and icons
+ - Improved labeling for form items and icons
  - Additional regions and landmarks
  - Improved announcement and focus handling on automatically updating pages
  - Contrast improvements for links and buttons

--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -9,15 +9,25 @@ v4.2 Release Notes
 Acknowledgments
 ---------------
 
-Accessibility Recommendations
------------------------------
+Accessibility
+-------------
 
-A VPAT has been created for version 4.2 and outlines the compliance of Open OnDemand with the WCAG AA standard.
+Open OnDemand v4.2 includes many accessibility improvements across the dashboard and core applications. These include:
+
+ - Additional support for keyboard navigation
+ - Improved labelling for form items and icons
+ - Additional regions and landmarks
+ - Improved announcement and focus handling on automatically updating pages
+ - Contrast improvements for links and buttons
+ - Improved alerting experience with screen readers
+
+A VPAT has been created for version 4.2 which outlines the compliance of Open OnDemand with the WCAG AA standard.
 Changes in version 4.2 ensure that immutable aspects of OnDemand are accessible by default, but do not account for
 customizations configured on individual instances. An individual instance should be reviewed separately for compliance,
 but we recommend specifically checking the following configurations that are directly related to WCAG guidelines.
 
-- Ensure ``show_all_apps_link`` is set to true to satisfy `2.4.5 Multiple Ways <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc>`_
+ - Ensure ``show_all_apps_link`` is set to true to satisfy `2.4.5 Multiple Ways <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc>`_
+   
    - This page acts as a searchable site map to all the enabled apps on your system. In addition to enabling the link in the navbar, it may be helpful to call attention and link to it in your :ref:`homepage welcome message <change_welcome_html>`.
    - The default value has been changed from false to true in v4.2. Ensure that your custom configuration does not override this default.
    - The ``show_all_apps_link`` configuration can be set through the environment variable ``SHOW_ALL_APPS_LINK`` or in your :ref:`ondemand-d-ymls`.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/add-accessibility-summary/release-notes/v4.2-release-notes.html

Changes the first technical section title from 'Accessibility Recommendations' to 'Accessibility', and adds a bulleted summary of general accessibility improvements before the existing discussion of the VPAT and recommendations. Leaving this open for review in case I missed anything we want to highlight

