### PR TITLE
start an accessibility page and fix 1360 in it

### DIFF
--- a/source/accessibility.rst
+++ b/source/accessibility.rst
@@ -1,0 +1,29 @@
+.. _accessibility:
+
+Accessibility
+=============
+
+Introduction
+------------
+
+Open OnDemand has went through several reviews and updates to meet
+`WCAG`_ 2.2 guidelines.  However, there are a few steps centers need to
+take to achieve complete complaince.  These steps are documented here along
+with areas or certian features that are not complaint.
+
+
+Additional configurations needed.
+---------------------------------
+
+Here is a list of additional configurations that are needed to acheive full
+complaince with the `WCAG`_ 2.2 guidelines.  Open OnDemand cannot ship with
+as they may be site specific.
+
+
+* `WCAG criterion 3.2.6 "Conistent Help"`_: Centers need to :ref:`extend the help menu <help_menu_guide>`
+  to complete this criteria.
+
+
+.. _WCAG: https://www.w3.org/WAI/standards-guidelines/wcag/
+.. _WCAG criterion 3.2.6 "Conistent Help": https://www.w3.org/TR/WCAG22/#consistent-help
+

--- a/source/accessibility.rst
+++ b/source/accessibility.rst
@@ -15,7 +15,7 @@ with areas or certain features that are not complaint.
 Additional configurations needed.
 ---------------------------------
 
-Here is a list of additional configurations that are needed to acheive full
+Here is a list of additional configurations that are needed to achieve full
 compliance with the `WCAG`_ 2.2 guidelines.  Open OnDemand cannot ship with
 as they may be site specific.
 

--- a/source/accessibility.rst
+++ b/source/accessibility.rst
@@ -8,15 +8,15 @@ Introduction
 
 Open OnDemand has undergone several reviews and updates to meet
 `WCAG`_ 2.2 guidelines.  However, there are a few steps centers need to
-take to achieve complete complaince.  These steps are documented here along
-with areas or certian features that are not complaint.
+take to achieve complete compliance.  These steps are documented here along
+with areas or certain features that are not complaint.
 
 
 Additional configurations needed.
 ---------------------------------
 
 Here is a list of additional configurations that are needed to acheive full
-complaince with the `WCAG`_ 2.2 guidelines.  Open OnDemand cannot ship with
+compliance with the `WCAG`_ 2.2 guidelines.  Open OnDemand cannot ship with
 as they may be site specific.
 
 

--- a/source/accessibility.rst
+++ b/source/accessibility.rst
@@ -6,7 +6,7 @@ Accessibility
 Introduction
 ------------
 
-Open OnDemand has went through several reviews and updates to meet
+Open OnDemand has undergone several reviews and updates to meet
 `WCAG`_ 2.2 guidelines.  However, there are a few steps centers need to
 take to achieve complete complaince.  These steps are documented here along
 with areas or certian features that are not complaint.

--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -233,9 +233,9 @@ This will result in a CSS tag added to all dashboard pages with the path: ``/pub
 
   custom_css_files: ["/myfolder/custom-branding.css"]
 
-.. _help_menu_guide:
-
 .. include:: customizations/overriding-partials.inc
+
+.. _help_menu_guide:
 
 Add URLs to Help Menu
 ---------------------

--- a/source/index.rst
+++ b/source/index.rst
@@ -83,6 +83,7 @@ These are institutions who were early adopters or provided HPC resources for dev
   :caption: Reference
 
   architecture
+  accessibility
   reference
   security
   release-notes


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/add-a11y-page/

This adds an entire page for accessibility detailing what additional steps centers may need to do to achieve full compliance.

Fixes #1360 to initialize the page.

I didn't update the RNs as I know they're still a bit in flight.
