### PR TITLE
Refactor accessibility

### DIFF
--- a/source/accessibility.rst
+++ b/source/accessibility.rst
@@ -11,19 +11,4 @@ Open OnDemand has undergone several reviews and updates to meet
 take to achieve complete compliance.  These steps are documented here along
 with areas or certain features that are not complaint.
 
-
-Additional configurations needed.
----------------------------------
-
-Here is a list of additional configurations that are needed to achieve full
-compliance with the `WCAG`_ 2.2 guidelines.  Open OnDemand cannot ship with
-as they may be site specific.
-
-
-* `WCAG criterion 3.2.6 "Conistent Help"`_: Centers need to :ref:`extend the help menu <help_menu_guide>`
-  to complete this criteria.
-
-
-.. _WCAG: https://www.w3.org/WAI/standards-guidelines/wcag/
-.. _WCAG criterion 3.2.6 "Conistent Help": https://www.w3.org/TR/WCAG22/#consistent-help
-
+.. include:: accessibility_settings.inc

--- a/source/accessibility_settings.inc
+++ b/source/accessibility_settings.inc
@@ -8,10 +8,10 @@ as they may be site specific.
 
 * `WCAG criterion 2.4.5 "Multiple Ways"`_: Centers need to enable the :ref:`show_all_apps_link configuration <show_all_apps_link>`
   to complete this criteria.
-* `WCAG criterion 3.2.6 "Conistent Help"`_: Centers need to :ref:`extend the help menu <help_menu_guide>`
+* `WCAG criterion 3.2.6 "Consistent Help"`_: Centers need to :ref:`extend the help menu <help_menu_guide>`
   to complete this criteria.
 
 
 .. _WCAG: https://www.w3.org/WAI/standards-guidelines/wcag/
-.. _WCAG criterion 3.2.6 "Conistent Help": https://www.w3.org/TR/WCAG22/#consistent-help
+.. _WCAG criterion 3.2.6 "Consistent Help": https://www.w3.org/TR/WCAG22/#consistent-help
 .. _WCAG criterion 2.4.5 "Multiple Ways": http://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc

--- a/source/accessibility_settings.inc
+++ b/source/accessibility_settings.inc
@@ -1,0 +1,17 @@
+Additional configurations needed.
+---------------------------------
+
+Here is a list of additional configurations that are needed to achieve full
+compliance with the `WCAG`_ 2.2 guidelines.  Open OnDemand cannot ship with
+as they may be site specific.
+
+
+* `WCAG criterion 2.4.5 "Multiple Ways"`_: Centers need to enable the :ref:`show_all_apps_link configuration <show_all_apps_link>`
+  to complete this criteria.
+* `WCAG criterion 3.2.6 "Conistent Help"`_: Centers need to :ref:`extend the help menu <help_menu_guide>`
+  to complete this criteria.
+
+
+.. _WCAG: https://www.w3.org/WAI/standards-guidelines/wcag/
+.. _WCAG criterion 3.2.6 "Conistent Help": https://www.w3.org/TR/WCAG22/#consistent-help
+.. _WCAG criterion 2.4.5 "Multiple Ways": http://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc

--- a/source/reference/files/ondemand-d-ymls.rst
+++ b/source/reference/files/ondemand-d-ymls.rst
@@ -290,6 +290,7 @@ Configuration Properties with profile support
 
         dashboard_title: "My Institution"
 
+.. _show_all_apps_link:
 .. describe:: show_all_apps_link (Bool, false)
 
   Whether to show the ``All Apps`` link in the navbar.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/refactor-accessibility/

This refactors the accessability page just a little to have an `.inc` file that could be included in the release notes.

The release notes go into more depth than I thought needed, so I didn't refactor that page to use the `.inc` file, but it could. Or it could just link out to the accessibility page - or both.
