### PR TITLE
Update v4.2 release notes with contributor acknowledgments

### DIFF
--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -26,7 +26,7 @@ main OnDemand codebase.
 **harshit-soora** contributed the ``OOD_WORKFLOW_SYNC_KEY`` feature, enabling synchronized launchers
 within a workflow, as well as updates to the Project Manager tutorial and documentation.
  
-**robinkar** fixed parsing of canceled sacct job states in ``ood_core`` and improved escaping of
+**robinkar** fixed parsing of canceled ``sacct`` job states in ``ood_core`` and improved escaping of
 option values for CSS selectors.
  
 **karcaw** contributed ``mod_ood_proxy`` HSTS header support.

--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -30,6 +30,9 @@ option values for CSS selectors.
  
 **karcaw** contributed ``mod_ood_proxy`` HSTS header support.
 
+**finchnSNPs** and **folkwest** reported accessibility gaps in the job status table, files app, and the
+Project Manager, which contribute to the community feedback that helps improve Open OnDemand.
+
 We'd also like to extend a big thank you to those listed below for contributing to Open OnDemand for the
 first time in this release. These contributions span the ``ondemand``, ``ood_core``, and
 ``ood-documentation`` GitHub repositories and include **9** first-time contributors.

--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -9,6 +9,44 @@ v4.2 Release Notes
 Acknowledgments
 ---------------
 
+Thank you to all of the community members who contributed code, documentation, suggestions, 
+bug reports, and other assistance across the project! We would like to recognize the following 
+individuals for their contributions to the Open OnDemand version 4.2 release.
+ 
+**mrobbert** contributed the cluster_info API for the PBSPro job adapter in ``ood_core``, and ensured
+KDE desktops can correctly use ``startplasma-x11`` when available.
+ 
+**james-s-willis** fixed quota bar display, preventing bars from extending over 100%, and fixed the
+``file_quotas`` widget on custom pages.
+
+**andrejcermak** contributed adding an OpenStack helper and refactoring coder logs functionality 
+in ``ood_core``, as well as caching improvements for ``BatchConnect::App.from_token`` in the 
+main OnDemand codebase.
+ 
+**harshit-soora** contributed the ``OOD_WORKFLOW_SYNC_KEY`` feature, enabling synchronized launchers
+within a workflow, as well as updates to the Project Manager tutorial and documentation.
+ 
+**robinkar** fixed parsing of canceled sacct job states in ``ood_core`` and improved escaping of
+option values for CSS selectors.
+ 
+**karcaw** contributed ``mod_ood_proxy`` HSTS header support.
+
+We'd also like to extend a big thank you to those listed below for contributing to Open OnDemand for the
+first time in this release. These contributions span the ``ondemand``, ``ood_core``, and
+``ood-documentation`` GitHub repositories and include **9** first-time contributors.
+ 
+* ``mrobbert`` made their first contribution in `ood_core#930 <https://github.com/OSC/ood_core/pull/930>`_
+* ``james-s-willis`` made their first contribution in `#5097 <https://github.com/OSC/ondemand/pull/5097>`_
+* ``mrobbert`` made their first contribution in `#5156 <https://github.com/OSC/ondemand/pull/5156>`_
+* ``clooty217`` made their first contribution in `#5246 <https://github.com/OSC/ondemand/pull/5246>`_
+* ``bstepanovski`` made their first contribution in `#5294 <https://github.com/OSC/ondemand/pull/5294>`_
+* ``andrejcermak`` made their first contribution in `#5299 <https://github.com/OSC/ondemand/pull/5299>`_
+* ``asubah`` made their first contribution in `ood-documentation#1332 <https://github.com/OSC/ood-documentation/pull/1332>`_
+* ``mcglow2`` made their first contribution in `ood-documentation#1315 <https://github.com/OSC/ood-documentation/pull/1315>`_
+* ``harshit-soora`` made their first contribution in `ood-documentation#1329 <https://github.com/OSC/ood-documentation/pull/1329>`_
+* ``iqlinuxadmin`` made their first contribution in `ood-documentation#1323 <https://github.com/OSC/ood-documentation/pull/1323>`_
+
+
 Accessibility
 -------------
 

--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -20,8 +20,7 @@ KDE desktops can correctly use ``startplasma-x11`` when available.
 ``file_quotas`` widget on custom pages.
 
 **andrejcermak** contributed adding an OpenStack helper and refactoring coder logs functionality 
-in ``ood_core``, as well as caching improvements for ``BatchConnect::App.from_token`` in the 
-main OnDemand codebase.
+in ``ood_core``, as well as caching improvements for ``BatchConnect::App.from_token`` in ``ondemand``.
  
 **harshit-soora** contributed the ``OOD_WORKFLOW_SYNC_KEY`` feature, enabling synchronized launchers
 within a workflow, as well as updates to the Project Manager tutorial and documentation.
@@ -35,12 +34,12 @@ We'd also like to extend a big thank you to those listed below for contributing 
 first time in this release. These contributions span the ``ondemand``, ``ood_core``, and
 ``ood-documentation`` GitHub repositories and include **9** first-time contributors.
  
-* ``mrobbert`` made their first contribution in `ood_core#930 <https://github.com/OSC/ood_core/pull/930>`_
 * ``james-s-willis`` made their first contribution in `#5097 <https://github.com/OSC/ondemand/pull/5097>`_
 * ``mrobbert`` made their first contribution in `#5156 <https://github.com/OSC/ondemand/pull/5156>`_
 * ``clooty217`` made their first contribution in `#5246 <https://github.com/OSC/ondemand/pull/5246>`_
 * ``bstepanovski`` made their first contribution in `#5294 <https://github.com/OSC/ondemand/pull/5294>`_
 * ``andrejcermak`` made their first contribution in `#5299 <https://github.com/OSC/ondemand/pull/5299>`_
+* ``mrobbert`` made their first contribution in `ood_core#930 <https://github.com/OSC/ood_core/pull/930>`_
 * ``asubah`` made their first contribution in `ood-documentation#1332 <https://github.com/OSC/ood-documentation/pull/1332>`_
 * ``mcglow2`` made their first contribution in `ood-documentation#1315 <https://github.com/OSC/ood-documentation/pull/1315>`_
 * ``harshit-soora`` made their first contribution in `ood-documentation#1329 <https://github.com/OSC/ood-documentation/pull/1329>`_

--- a/source/spelling_wordlist.txt
+++ b/source/spelling_wordlist.txt
@@ -193,3 +193,7 @@ bstepanovski
 asubah
 mcglow2
 iqlinuxadmin
+mod_ood_proxy
+HSTS
+startplasma
+plasticize

--- a/source/spelling_wordlist.txt
+++ b/source/spelling_wordlist.txt
@@ -193,7 +193,3 @@ bstepanovski
 asubah
 mcglow2
 iqlinuxadmin
-mod_ood_proxy
-HSTS
-startplasma
-plasticize

--- a/source/spelling_wordlist.txt
+++ b/source/spelling_wordlist.txt
@@ -181,3 +181,15 @@ Horka
 Dataverse
 Zenodo
 poller
+coder
+mrobbert
+james-s-willis
+andrejcermak
+harshit-soora
+robinkar
+karcaw
+clooty217
+bstepanovski
+asubah
+mcglow2
+iqlinuxadmin


### PR DESCRIPTION
Added acknowledgments for contributors to the Open OnDemand 4.2 release

https://osc.github.io/ood-documentation-test/moffatsadeghi-acknowledgements
