### PR TITLE
Refactor title out of accessibility settings

### DIFF
--- a/source/accessibility.rst
+++ b/source/accessibility.rst
@@ -11,4 +11,7 @@ Open OnDemand has undergone several reviews and updates to meet
 take to achieve complete compliance.  These steps are documented here along
 with areas or certain features that are not complaint.
 
+
+Additional Configurations Needed
+--------------------------------
 .. include:: accessibility_settings.inc

--- a/source/accessibility_settings.inc
+++ b/source/accessibility_settings.inc
@@ -1,6 +1,3 @@
-Additional configurations needed.
----------------------------------
-
 Here is a list of additional configurations that are needed to achieve full
 compliance with the `WCAG`_ 2.2 guidelines.  Open OnDemand cannot ship with
 as they may be site specific.

--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -52,6 +52,9 @@ first time in this release. These contributions span the ``ondemand``, ``ood_cor
 Accessibility
 -------------
 
+Overview
+........
+
 Open OnDemand v4.2 includes many accessibility improvements across the dashboard and core applications. These include:
 
  - Additional support for keyboard navigation
@@ -64,6 +67,9 @@ Open OnDemand v4.2 includes many accessibility improvements across the dashboard
 A VPAT has been created for version 4.2 which outlines the compliance of Open OnDemand with the WCAG AA standard.
 Changes in version 4.2 ensure that immutable aspects of OnDemand are accessible by default, but do not account for
 customizations configured on individual instances. 
+
+Additional Accessibility Configurations
+.......................................
 
 .. include:: ../accessibility_settings.inc
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/refactor-accessibility_settings.inc/

This originated with attempting to make the title consistent with other release note titles. However it seemed like the two different contexts that this list appear in call for two different titles. This also allows us to give it a proper sub-heading in the release notes as part of the accessibility section