### PR TITLE
Update v4.2 release notes with SBOM information

### DIFF
--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -48,6 +48,15 @@ first time in this release. These contributions span the ``ondemand``, ``ood_cor
 * ``harshit-soora`` made their first contribution in `ood-documentation#1329 <https://github.com/OSC/ood-documentation/pull/1329>`_
 * ``iqlinuxadmin`` made their first contribution in `ood-documentation#1323 <https://github.com/OSC/ood-documentation/pull/1323>`_
 
+Authentication and Security
+---------------------------
+
+Software Bill of Materials
+..........................
+
+Open OnDemand version 4.2 includes a Software Bill of Materials (SBOM) outlining the
+operating system-level software dependencies for Open OnDemand. For more information, 
+please see the INSERT REPO LINK HERE FROM Travis.
 
 Accessibility
 -------------


### PR DESCRIPTION
Added section on Software Bill of Materials to release notes.

https://osc.github.io/ood-documentation-test/moffatsadeghi-patch-dbom

start SBOM section
