### PR TITLE
add note for custom pages and Passenger applications

### DIFF
--- a/source/accessibility.rst
+++ b/source/accessibility.rst
@@ -15,3 +15,12 @@ with areas or certain features that are not complaint.
 Additional Configurations Needed
 --------------------------------
 .. include:: accessibility_settings.inc
+
+Custom pages and Passenger applications
+---------------------------------------
+
+Centers that provide additional custom web pages, dashboard widgets, Passenger
+applications and so on should take care to meet the `WCAG`_ 2.2 guidelines.
+The developers of Open OnDemand can only manage and review the pages that
+are shipped in the packages, not any custom pages or Passenger applications
+that have been developed by any given center.


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/accessible-apps/

Fixes #1339, unless we want this in the release notes as well? I just added it to the accessibility page.
