### PR TITLE
Revise SBOM section in v4.2 release notes

### DIFF
--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -54,9 +54,14 @@ Authentication and Security
 Software Bill of Materials
 ..........................
 
-Open OnDemand version 4.2 includes a Software Bill of Materials (SBOM) outlining the
-operating system-level software dependencies for Open OnDemand. For more information, 
-please see the INSERT REPO LINK HERE FROM Travis.
+Version 4.2 includes a Software Bill of Materials (SBOM) that outlines the
+operating system-level software dependencies for Open OnDemand. Based on community
+feedback, the SBOM is moving to an industry-standard format and will be maintained
+in a dedicated OSC repository.
+
+The ``Open-OnDemand-SBOM`` repository is still being built out and these release notes
+will be updated after the Open OnDemand 4.2 release to help sites review dependency information
+for security and compliance workflows.
 
 Accessibility
 -------------


### PR DESCRIPTION
Updated the Software Bill of Materials section to reflect changes based on community feedback and added information about the dedicated OSC repository.

https://osc.github.io/ood-documentation-test/moffatsadeghi-sbom-newinfo
