### PR TITLE
support codespaces in `rake open` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,8 @@ desc "Open built documentation in browser"
 task :open do
   if windows?
     system 'start .\build\html\index.html'
+  elsif codespace?
+    exec 'python -m http.server 8000 --directory build/html'
   else
     exec '(command -v xdg-open >/dev/null 2>&1 && xdg-open build/html/index.html) || open build/html/index.html'
   end
@@ -53,6 +55,10 @@ end
 
 def windows?
   Gem.win_platform?
+end
+
+def codespace?
+  ENV['CODESPACES'] == 'true'
 end
 
 def run_cmd

--- a/tasks.py
+++ b/tasks.py
@@ -21,6 +21,8 @@ PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 def is_windows() -> bool:
     return platform.system().lower().startswith("win")
 
+def is_codespace() -> bool:
+    return (os.getenv('CODESPACES') == 'true')
 
 def exists(program: str) -> bool:
     # Cross-platform check if a program exists in PATH
@@ -109,7 +111,8 @@ def cmd_open(_args) -> int:
         except OSError as e:
             print(f"Failed to open {index_path}: {e}", file=sys.stderr)
             return 1
-
+    if is_codespace():
+        return _print_and_exec(["python", "-m", "http.server", "8000", "--directory", "build/html"])
     if shutil.which("xdg-open"):
         return subprocess.call(["xdg-open", index_path])
     if shutil.which("open"):


### PR DESCRIPTION
Fixes #1387. Adds a helper method to tell when the file is being run in codespaces and adds the proper command to the rake open and python open task
