### PR TITLE
Revise 4.2 release notes for SBOM updates

### DIFF
--- a/source/release-notes/v4.2-release-notes.rst
+++ b/source/release-notes/v4.2-release-notes.rst
@@ -56,12 +56,13 @@ Software Bill of Materials
 
 Version 4.2 includes a Software Bill of Materials (SBOM) that outlines the
 operating system-level software dependencies for Open OnDemand. Based on community
-feedback, the SBOM is moving to an industry-standard format and will be maintained
+feedback, the SBOM has moved to an industry-standard format and will be maintained
 in a dedicated OSC repository.
 
-The ``Open-OnDemand-SBOM`` repository is still being built out and these release notes
-will be updated after the Open OnDemand 4.2 release to help sites review dependency information
-for security and compliance workflows.
+The `Open-OnDemand-SBOM <https://github.com/OSC/open-ondemand-sbom>`_ repository
+is available for version 4.2, with additional structure and documentation still
+being built out. This repository is intended to help sites review dependency
+information for security and compliance workflows.
 
 Accessibility
 -------------


### PR DESCRIPTION
Updated release notes for version 4.2 to reflect changes in the Software Bill of Materials (SBOM) repo details.

https://osc.github.io/ood-documentation-test/sbom-update

Repo is now ready - provided the link and reworded that section to fit with what was there before. 