### PR TITLE
Label oidc_crypto_passphrase correctly

### DIFF
--- a/source/reference/files/ood-portal-yml.rst
+++ b/source/reference/files/ood-portal-yml.rst
@@ -1060,7 +1060,7 @@ on mod_auth_openidc_.
 
         .. code-block:: yaml
 
-          oidc_uri: "97b85f06-7a23-11f1-9e51-00155def9328"
+          oidc_crypto_passphrase: "97b85f06-7a23-11f1-9e51-00155def9328"
 
 .. describe:: oidc_uri (String, null)
 


### PR DESCRIPTION
Fix oidc_crypto_passphrase labelling.
