### PR TITLE
Update Docker image version to v3.2.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ def user_group
 end
 
 def image
-  'ohiosupercomputer/ood-doc-build:v3.1.0'
+  'ohiosupercomputer/ood-doc-build:v3.2.0'
 end
 
 def docker?


### PR DESCRIPTION
Upgrades the version of the `ood-documentation-build` container, allowing #1393 and #1406 to pass tests