### PR TITLE
correct this default

### DIFF
--- a/source/reference/files/ondemand-d-ymls.rst
+++ b/source/reference/files/ondemand-d-ymls.rst
@@ -291,7 +291,7 @@ Configuration Properties with profile support
         dashboard_title: "My Institution"
 
 .. _show_all_apps_link:
-.. describe:: show_all_apps_link (Bool, false)
+.. describe:: show_all_apps_link (Bool, true)
 
   Whether to show the ``All Apps`` link in the navbar.
   This links to the Dashboard page showing all system installed applications.


### PR DESCRIPTION
This default is true as the section indicates.

https://osc.github.io/ood-documentation-test/johrstrom-patch-1/

This default is `true` as the section below it indicates.
