### PR TITLE
update build from source docs

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -27,17 +27,4 @@ Open OnDemand, by default, expects Apache to have SSL enabled by :ref:`securing 
    installation/add-ssl
    installation/modify-system-security
 
-Building From Source
---------------------
-
-Building from source is left as an exercise to the reader. 
-     
-It's not particularly difficult to build the code, but installing it with all the various files is. Should you be interested, 
-review the ``Dockerfile.example`` and packaging specs for what would be involved.
-
-- https://github.com/OSC/ondemand/blob/master/Dockerfile.example
-- https://github.com/OSC/ondemand/tree/master/packaging
-
-If you'd like a package built for a system that we don't currently support, feel free to open a ticket!
-
 - https://github.com/OSC/ondemand/issues/new

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -212,13 +212,12 @@ Building From Source
 Building from source is left as an exercise to the reader. 
      
 It's not particularly difficult to build the code, but installing it with all the various files is. Should you be interested, 
-review the ``Dockerfile`` and packaging specs for what would be involved.
+review the packaging specs and rules for what would be involved.
 
-- https://github.com/OSC/ondemand/blob/master/Dockerfile.example
 - https://github.com/OSC/ondemand/tree/master/packaging
 
 If you'd like a package built for a system that we don't currently support, feel free to open a ticket!
 
-- https://github.com/OSC/ondemand/issues/new
+- https://github.com/OSC/ondemand/issues/new?template=feature-request.md
 
 .. _ohio supercomputer center: https://www.osc.edu/

--- a/source/installation/install-software.rst
+++ b/source/installation/install-software.rst
@@ -209,10 +209,10 @@ and likely :ref:`configure a servername <ood-portal-generator-servername>`.
 Building From Source
 --------------------
 
-Building from source is left as an exercise to the reader. 
-     
-It's not particularly difficult to build the code, but installing it with all the various files is. Should you be interested, 
-review the packaging specs and rules for what would be involved.
+Detailed instructions for building from source are not provided here.
+
+If you're interested in building from source, review the packaging specs and
+rules for more information about what is involved.
 
 - https://github.com/OSC/ondemand/tree/master/packaging
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation-test/update-src-build/

Fixes #1410  by updating building from source documentation. For whatever reason, this was left in two different spots, so this removes one of the entries.
